### PR TITLE
Docs: README Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Data dependencies are described via **resources**, which are accessed and potent
 
 Each task has an annotation how the resources are accessed.
 Therein allowed **access modes** depend on the type of the resource.
-A simple example would be read/write, but also more complex operations are possible, e.g. accessing sub-regions of a sequence-container or other atomic, commutative operations besides read.
-A *resource* can be associated with a specific *access mode* forming a **resource access**. These instances of a *resource access* can then be pairwise tested wheter they are conflicting and thereby creating a data-dependency (e.g. two writes to the same resource).
+A simple example would be read/write, but also more complex operations are possible, e.g., accessing sub-regions of a sequence-container or other atomic, commutative operations besides read.
+A *resource* can be associated with a specific *access mode* forming a **resource access**. These instances of a *resource access* can then be pairwise tested wheter they are conflicting and thereby creating a data-dependency (e.g., two writes to the same resource).
 So each task carries a list of these resource-accesses in its so-called **task-properties**.
 If two tasks have conflicting resource-accesses, the first created task is executed first.
-This is exactly the behaviour that one would also achieve when programming serially, without hints given via resources.
+This is exactly the behavior that one would also achieve when programming serially, without hints given via resources.
 
 When tasks are created, their resource-access list is compared against the previous enqueued tasks and corresponding dependencies are created in the task-graph.
-The resulting task-graph is read by a scheduling algorithm that executes individual tasks, e.g. across parallel threads.
+The resulting task-graph is read by a scheduling algorithm that executes individual tasks, e.g., across parallel threads.
 
 ### Example
 
@@ -125,7 +125,7 @@ However since we want to achieve **declarative task dependencies**, for which th
 | [TaskFlow](https://taskflow.github.io/)                                   | :heavy_check_mark:    | :heavy_check_mark:  | -                              | -                                             | :heavy_check_mark:              | :x:                             | :x:                            | :x:                                 |
 
 1. user controllable, decoupled helper code, but included with RedGrapes
-2. events can be triggered externally, e.g. from a polling loop
+2. events can be triggered externally, e.g., from a polling loop
 3. only implicitly managed, not user controlled
 4. see [hipSYCL#181](https://github.com/illuhad/hipSYCL/issues/181)
 

--- a/README.md
+++ b/README.md
@@ -97,17 +97,17 @@ The more low-level approach is to just create tasks as executable unit and **imp
 This approach may be called "data-driven", because the dependencies can be created by waiting for futures of other tasks. <!--, so basically it is an implementation of an async scheduler.-->
 However since we want to achieve **declarative task dependencies**, for which the runtime must also be aware of shared states to automatically detect data dependencies in order to derive the task-graph, the aforementioned approach does not suffice and we can exclude this entire class of runtime-systems.
 
-**compile time checked memory access**: The automatic creation of a task graph is often done via annotations, e.g. a pragma in OpenMP, but that does not guarantee the correctness of the access specifications. RedGrapes leverages the type system to write relatively safe code in that regard.
+**compile time checked memory access**: The automatic creation of a task graph is often done via annotations, e.g., a pragma in OpenMP, but that does not guarantee the correctness of the access specifications. RedGrapes leverages the type system to write relatively safe code in that regard.
 
 **native C++**: PaRSEC has a complicated toolchain using additional compilers, OpenMP makes use of pragmas that require compiler support. RedGrapes only requires the C++14 standard.
 
-**typesafe**: Some libraries like Legion or StarPU use a very old fashioned, untyped argc/argv interface to pass parameters to tasks (very dangerous). Both libraries in general also require a lot of C-style boilerplate.
+**typesafe**: Some libraries like Legion or StarPU use an untyped ``argc``/``argv`` interface to pass parameters to tasks, which is error-prone. Both libraries in general also require a lot of C-style boilerplate.
 
-**custom access modes**: RedGrapes supports arbitrary, user-configurable access modes beyond read/write, e.g. accesses to sub-areas of a multi-dimensional buffer can be described properly.
+**custom access modes**: RedGrapes supports arbitrary, user-configurable access modes beyond read/write, e.g., accesses to sub-areas of a multi-dimensional buffer can be described properly.
 
 **integration with asynchronous APIs**: To correctly model asynchronous MPI or CUDA calls, the complete operation should be a task, but still not block. The finishing of the asynchronous operation has to be triggered externally. Systems that implement distributed scheduling do not leave this option since the communication is done by the runtime itself.
 
-**inter-process scheduling**: Legion, StarPU, HPX etc. add another layer of abstraction to provide a virtualized programming interface for multiple nodes in a HPC-cluster. This implies that the domain decomposition, communication and task-migration is handled to some extent implicitly by the tasking-runtime. This is out of scope for redGrapes, but could be built on top rather than tightly coupling it.
+**inter-process scheduling**: Legion, StarPU, HPX, etc. add another layer of abstraction to provide a virtualized programming interface for multiple nodes in a HPC-cluster. This implies that the domain decomposition, communication and task-migration is handled to some extent implicitly by the tasking-runtime. This is out of scope for RedGrapes, but could be built on top rather than tightly coupling it.
 
 | **Feature**                                                               | <sup>native C++</sup> | <sup>typesafe</sup> | <sup>custom access modes</sup> | <sup>compile time checked memory access</sup> | <sup>CUDA<sup>                  | <sup>&nbsp;MPI&nbsp;</sub>      | <sup>other async APIs</sup>    | <sup>inter-process scheduling</sup> |
 |---------------------------------------------------------------------------|-----------------------|---------------------|--------------------------------|-----------------------------------------------|---------------------------------|---------------------------------|--------------------------------|-------------------------------------|
@@ -124,10 +124,10 @@ However since we want to achieve **declarative task dependencies**, for which th
 | [HPX](http://stellar.cct.lsu.edu/projects/hpx/)                           | :heavy_check_mark:    | :heavy_check_mark:  | -                              | -                                             | :heavy_check_mark:              | :heavy_check_mark: <sup>3</sup> | :x:                            | :heavy_check_mark:                  |
 | [TaskFlow](https://taskflow.github.io/)                                   | :heavy_check_mark:    | :heavy_check_mark:  | -                              | -                                             | :heavy_check_mark:              | :x:                             | :x:                            | :x:                                 |
 
-1. user controllable, decoupled helper code, but included with redGrapes
-2. Events can be triggered extrenally, e.g. from a polling loop
+1. user controllable, decoupled helper code, but included with RedGrapes
+2. events can be triggered externally, e.g. from a polling loop
 3. only implicitly managed, not user controlled
-4. See [hipSYCL#181](https://github.com/illuhad/hipSYCL/issues/181)
+4. see [hipSYCL#181](https://github.com/illuhad/hipSYCL/issues/181)
 
 *Note*: Should any libraries be misrepresented here, corrections are welcome.
 
@@ -138,7 +138,7 @@ This Project is free software, licensed under the [Mozilla MPL 2.0 license](LICE
 
 ## Author Contributions
 
-RedGrapes is developed by members of the [Computational Radiation Physics Group](https://hzdr.de/crp) at [HZDR](https://www.hzdr.de/).
+RedGrapes is developed by members of the [Computational Radiation Physics Group](https://hzdr.de/crp) at [HZDR](https://www.hzdr.de).
 Its conceptual design is based on a [whitepaper by A. Huebl, R. Widera, and A. Matthes (2017)](docs/2017_02_ResourceManagerDraft.pdf). 
 
 * [Michael Sippel](https://github.com/michaelsippel): library design & implementation
@@ -154,7 +154,7 @@ RedGrapes requires a compiler supporting the C++14 standard.
 RedGrapes further depends on the following libraries:
 
 * [optional for C++14](https://github.com/akrzemi1/Optional) by [Andrzej Krzemienski](https://github.com/akrzemi1)
-* [ConcurrentQueue](https://github.com/cameron314/concurrentqueue) by [Cameron Desrochers](https://moodycamel.com/)
+* [ConcurrentQueue](https://github.com/cameron314/concurrentqueue) by [Cameron Desrochers](https://moodycamel.com)
 * [spdlog](https://github.com/gabime/spdlog)
 * [{fmt}](https://fmt.dev)
 * (Optionally for testing) [Catch2](https://github.com/catchorg/Catch2)


### PR DESCRIPTION
This updates the README file:

- fix a few typos
- unify spellings of RedGrapes
- clean ups / simplifcations