### PR TITLE
CI: Add Ubuntu

### DIFF
--- a/.github/workflows/dependencies/gcc.sh
+++ b/.github/workflows/dependencies/gcc.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The RedGrapes Community
+#
+# License: MPL-2.0
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y  \
+    build-essential      \
+    ca-certificates      \
+    ccache               \
+    cmake                \
+    gnupg                \
+    libboost-context-dev \
+    libfmt-dev           \
+    libfreetype-dev      \
+    liblapack-dev        \
+    liblapacke-dev       \
+    libopenmpi-dev       \
+    libpng-dev           \
+    libspdlog-dev        \
+    ninja-build
+
+# cmake-easyinstall
+#
+sudo curl -L -o /usr/local/bin/cmake-easyinstall https://git.io/JvLxY
+sudo chmod a+x /usr/local/bin/cmake-easyinstall
+export CEI_SUDO="sudo"
+export CEI_TMP="/tmp/cei"
+
+# PNGwriter
+#
+CXXFLAGS="" cmake-easyinstall --prefix=/usr/local  \
+    git+https://github.com/pngwriter/pngwriter.git \
+    -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,47 @@
+name: 🐧 Ubuntu
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu
+  cancel-in-progress: true
+
+jobs:
+  build_gcc:
+    name: GCC
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
+    env:
+      CXXFLAGS: "-Wall -Wextra -Wshadow"
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        .github/workflows/dependencies/gcc.sh
+    - name: CCache Cache
+      uses: actions/cache@v2
+      # - once stored under a key, they become immutable (even if local cache path content changes)
+      # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+      with:
+        path: |
+          ~/.ccache
+          ~/.cache/ccache
+        key: ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-${{ hashFiles('CMakeLists.txt') }}
+        restore-keys: |
+          ccache-openmp-cxxminimal-${{ hashFiles('.github/workflows/ubuntu.yml') }}-
+          ccache-openmp-cxxminimal-
+    - name: build RedGrapes
+      run: |
+        cmake \
+          -S .                                 \
+          -B build                             \
+          -G Ninja                             \
+          -DCMAKE_BUILD_TYPE=Debug             \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_VERBOSE_MAKEFILE=ON
+
+        cmake --build build -j 2
+
+    - name: test RedGrapes
+      run: |
+        ctest --test-dir build --output-on-failure

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -38,7 +38,8 @@ jobs:
           -G Ninja                             \
           -DCMAKE_BUILD_TYPE=Debug             \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_VERBOSE_MAKEFILE=ON
+          -DCMAKE_VERBOSE_MAKEFILE=ON          \
+          -DredGrapes_BUILD_EXAMPLES=OFF
 
         cmake --build build -j 2
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Its conceptual design is based on a [whitepaper by A. Huebl, R. Widera, and A. M
 
 * [Michael Sippel](https://github.com/michaelsippel): library design & implementation
 * [Dr. Sergei Bastrakov](https://github.com/sbastrakov): supervision
-* [Dr. Axel Huebl](https://github.com/ax3l): whitepaper, supervision
+* [Dr. Axel Huebl](https://github.com/ax3l): whitepaper, supervision, CI
 * [René Widera](https://github.com/psychocoderHPC): whitepaper, supervision
 * [Alexander Matthes](https://github.com/theZiz): whitepaper
 


### PR DESCRIPTION
Add Ubuntu CI. This features:
- Ubuntu 20.04 LTS build with g++ 9.4.0
- Verbose debug build (thus, with asserts enabled)
- Effective caching between subsequent CI runs
- auto-cancellation on updated PRs / branches: only run newer commit

This installs a ton of undocumented dependencies for the default-on examples. The missing documentation for these needs to be done separately, independent of this PR.