### PR TITLE
CI: actually run tests

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -39,10 +39,11 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug             \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DCMAKE_VERBOSE_MAKEFILE=ON          \
+          -DBUILD_TESTING=ON                   \
           -DredGrapes_BUILD_EXAMPLES=ON
 
         cmake --build build -j 2
 
     - name: test RedGrapes
       run: |
-        ctest --test-dir build --output-on-failure
+        ctest --test-dir build/test --output-on-failure

--- a/redGrapesConfig.cmake
+++ b/redGrapesConfig.cmake
@@ -9,6 +9,7 @@ find_package(Boost 1.62.0 REQUIRED COMPONENTS context)
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
 
+if( NOT TARGET redGrapes )
 add_library(redGrapes
   ${CMAKE_CURRENT_LIST_DIR}/redGrapes/resource/resource.cpp
   ${CMAKE_CURRENT_LIST_DIR}/redGrapes/dispatch/thread/execute.cpp
@@ -19,6 +20,7 @@ add_library(redGrapes
   ${CMAKE_CURRENT_LIST_DIR}/redGrapes/task/task_space.cpp
   ${CMAKE_CURRENT_LIST_DIR}/redGrapes/redGrapes.cpp
 )
+endif()
 
 target_compile_features(redGrapes PUBLIC
     cxx_std_14


### PR DESCRIPTION
To build the tests, they need to be enabled with BUILD_TESTING=ON.
However when building both examples and tests together at the same time from the parent-CMake-project , it created the error that the redGrapes target is redefined, because both examples and tests do a find_package(redGrapes).
To fix this, I added a check in the redGrapesConfig.cmake and only call add_library if it was not defined before.  However I am not sure if this is the idiomatic way to solve this. Maybe @ax3l knows this.