### PR TITLE
fix memory leak

### DIFF
--- a/examples/1_resources.cpp
+++ b/examples/1_resources.cpp
@@ -5,12 +5,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <redGrapes/redGrapes.hpp>
 #include <redGrapes/resource/ioresource.hpp>
 #include <redGrapes/resource/fieldresource.hpp>
 #include <redGrapes/resource/resource_user.hpp>
 
 int main(int, char*[])
 {
+    redGrapes::init(1);
     redGrapes::FieldResource< std::vector<int> > a;
     redGrapes::IOResource<int> b;
     redGrapes::IOResource<int> c;
@@ -35,6 +37,7 @@ int main(int, char*[])
     std::cout << "is_serial(user1,user3) = " << redGrapes::ResourceUser::is_serial(user1,user3) << std::endl;
     std::cout << "is_serial(user2,user3) = " << redGrapes::ResourceUser::is_serial(user2,user3) << std::endl;
 
+    redGrapes::finalize();
     return 0;
 }
 


### PR DESCRIPTION
With #44 we tried to fix the memory leak which can happen if more than one thread is allocating a new chunk.
The PR #44 was not fixing the issue and introduced a double free issue.

- [ ] PR must be tested
    - [x] examples work on @psychocoderHPC  laptop  
- [x] this PR contains #47 else testing is not possible

@michaelsippel I have not tested the PR and wrote it blindly, we need to perform a runtime test before merging.