### PR TITLE
Fix freeze of worker

### DIFF
--- a/redGrapes/dispatch/thread/worker.cpp
+++ b/redGrapes/dispatch/thread/worker.cpp
@@ -32,7 +32,6 @@ WorkerThread::~WorkerThread()
 void WorkerThread::start()
 {
     thread = std::thread([this]{ this->run(); });
-    this->Worker::start();
 }
 
 Worker::Worker( memory::ChunkedBumpAlloc<memory::HwlocAlloc> & alloc, HwlocContext & hwloc_ctx, hwloc_obj_t const & obj, WorkerId worker_id )
@@ -44,12 +43,6 @@ Worker::Worker( memory::ChunkedBumpAlloc<memory::HwlocAlloc> & alloc, HwlocConte
 
 Worker::~Worker()
 {
-}
-
-void Worker::start()
-{
-    m_start.store(true, std::memory_order_release);
-    wake();
 }
 
 void Worker::stop()
@@ -82,12 +75,6 @@ void WorkerThread::run()
         throw std::runtime_error("idle in worker thread!");
     };
                 */
-
-    /* wait for start-flag to be triggerd in order
-     * to avoid premature access to `shared_from_this`
-     */
-    while( ! m_start.load(std::memory_order_consume) )
-        cv.wait();
 
     /* initialize thread-local variables
      */

--- a/redGrapes/dispatch/thread/worker.hpp
+++ b/redGrapes/dispatch/thread/worker.hpp
@@ -44,13 +44,6 @@ struct Worker
     //private:
     WorkerId id;
 
-    /*!
-     * if true, the thread shall start
-     * executing the jobs in its queue
-     * and request rescheduling if empty
-     */
-    std::atomic_bool m_start{ false };
-
     /*! if true, the thread shall stop
      * instead of waiting when it is out of jobs
      */
@@ -78,7 +71,6 @@ public:
     inline scheduler::WakerId get_waker_id() { return id + 1; }
     inline bool wake() { return cv.notify(); }
 
-    void start();
     virtual void stop();
 
     /* adds a new task to the emplacement queue
@@ -133,7 +125,7 @@ struct WorkerThread
     /* function the thread will execute
      */
     void run();
-    
+
     void cpubind();
     void membind();
 };


### PR DESCRIPTION
A race condition on the `cv` condition-variable in `Worker` caused a freeze in the `WorkerUtilization`-unittest.

This freeze happens because of two sequential calls to `wait()` without proper synchronization of `notify()`  in the case when the worker is assigned a new task before the worker starts its work-loop. There, first the Worker must progress to the start-barrier and enter the outer while-condition to wait for the start signal. Before `wait()` returns, both `Worker::start()` and the task-emplace sent their `notify()`,   but the `notify()` corresponding to the emplacement of the new task is lost in ambiguity with the start-signal.
Then the worker thread will wake up and jump to to `work_loop()` where it will wait again but the `notify()` which should wake the worker up was already sent and thus the worker will not wake up and the task will not be consumed.

In a 'real' scenario this might not be as apparent, because the worker will only be falsely inactive until the next task is emplaced which will wake the worker up and everything will continue normally.

This PR fixes this bug by eliminating the `CondVar`-based barrier before `work_loop()` which is also not required anymore because of recent refactorings.