### PR TITLE
Dont pull alias shared_mutex into the std namespace

### DIFF
--- a/redGrapes/redGrapes.cpp
+++ b/redGrapes/redGrapes.cpp
@@ -51,7 +51,7 @@ namespace redGrapes
                 SPDLOG_TRACE("create child space = {}", (void*) task_space.get());
                 current_task->children = task_space;
 
-                std::unique_lock<std::shared_mutex> wr_lock(current_task->space->active_child_spaces_mutex);
+                std::unique_lock<std::shared_timed_mutex> wr_lock(current_task->space->active_child_spaces_mutex);
                 current_task->space->active_child_spaces.push_back(task_space);
             }
 

--- a/redGrapes/scheduler/event.hpp
+++ b/redGrapes/scheduler/event.hpp
@@ -22,10 +22,6 @@
 #    define REDGRAPES_EVENT_FOLLOWER_LIST_CHUNKSIZE 16
 #endif
 
-namespace std
-{
-    using shared_mutex = shared_timed_mutex;
-} // namespace std
 
 namespace redGrapes
 {

--- a/redGrapes/sync/spinlock.hpp
+++ b/redGrapes/sync/spinlock.hpp
@@ -60,7 +60,7 @@ namespace redGrapes
         alignas(64) std::atomic<unsigned> reader_count;
         alignas(64) std::atomic<bool> write;
     #else
-        std::shared_mutex m;
+        std::shared_timed_mutex m;
     #endif
 
         SpinLock()

--- a/redGrapes/task/task_space.hpp
+++ b/redGrapes/task/task_space.hpp
@@ -28,7 +28,7 @@ namespace redGrapes
         unsigned depth;
         Task* parent;
 
-        std::shared_mutex active_child_spaces_mutex;
+        std::shared_timed_mutex active_child_spaces_mutex;
         std::vector<std::shared_ptr<TaskSpace>> active_child_spaces;
 
         virtual ~TaskSpace();


### PR DESCRIPTION
RedGrapes was redefining ``shared_mutex`` as an alias of ``shared_timed_mutex`` in the ``std`` namespace, which was causing compile errors when used with alpaka. In general this extension of std is at best undefined behavior and shouldn't be done.
This PR fixes this by explicitly calling ``std::shared_timed_mutex`` in redGrapes. Alternatively it is possible to do this alias in namespace redgrapes instead of pulling it into std, but especially with only a few places where ``std::shared_timed_mutex`` is used, this way seems more clear.
