### PR TITLE
GraphProperty: replace redundant `task` member with address calculation through offsetof

### DIFF
--- a/redGrapes/task/property/graph.hpp
+++ b/redGrapes/task/property/graph.hpp
@@ -49,15 +49,13 @@ namespace redGrapes
     {
         Task& operator*()
         {
-            return *task;
+            return *get_task();
         }
 
         Task* operator->()
         {
-            return task;
+            return get_task();
         }
-
-        Task* task;
 
         //! number of parents
         uint8_t scope_depth;
@@ -80,24 +78,26 @@ namespace redGrapes
         scheduler::Event result_set_event;
         scheduler::Event result_get_event;
 
+        Task* get_task();
+
         inline scheduler::EventPtr get_pre_event()
         {
-            return scheduler::EventPtr{scheduler::T_EVT_PRE, this->task};
+            return scheduler::EventPtr{scheduler::T_EVT_PRE, this->get_task()};
         }
 
         inline scheduler::EventPtr get_post_event()
         {
-            return scheduler::EventPtr{scheduler::T_EVT_POST, this->task};
+            return scheduler::EventPtr{scheduler::T_EVT_POST, this->get_task()};
         }
 
         inline scheduler::EventPtr get_result_set_event()
         {
-            return scheduler::EventPtr{scheduler::T_EVT_RES_SET, this->task};
+            return scheduler::EventPtr{scheduler::T_EVT_RES_SET, this->get_task()};
         }
 
         inline scheduler::EventPtr get_result_get_event()
         {
-            return scheduler::EventPtr{scheduler::T_EVT_RES_GET, this->task};
+            return scheduler::EventPtr{scheduler::T_EVT_RES_GET, this->get_task()};
         }
 
         inline bool is_ready()

--- a/redGrapes/task/task_space.cpp
+++ b/redGrapes/task/task_space.cpp
@@ -70,8 +70,8 @@ namespace redGrapes
     void TaskSpace::submit(Task* task)
     {
         TRACE_EVENT("TaskSpace", "submit()");
+
         task->space = shared_from_this();
-        task->task = task;
 
         ++task_count;
 


### PR DESCRIPTION
just for reference. not ready yet, extracted from #39 