### PR TITLE
Fix idle/wake logic

### DIFF
--- a/redGrapes/TaskCtx.hpp
+++ b/redGrapes/TaskCtx.hpp
@@ -21,8 +21,11 @@ namespace redGrapes
     struct TaskCtx
     {
         //! pause the currently running task at least until event is reached
-        // else is supposed to be called when .get() is called on emplace task, which calls the future .get(), so there
-        // is no current task at that time, unless this is in a child task space. we can assert(event.task != 0);
+        // else is supposed to be called when .get()/.submit() is called on emplace task, which calls the future
+        // .get(),
+        // if there is no current task at that time (not in a child task space) in the root space,wake up the parser
+        // thread
+        // we can assert(event.task != 0);
         static void yield(scheduler::EventPtr<TTask> event)
         {
             if(current_task)
@@ -32,7 +35,7 @@ namespace redGrapes
             }
             else
             {
-                event->waker_id = event.task->scheduler_p->getNextWorkerID() + 1;
+                event->waker_id = -2;
                 while(!event->is_reached())
                     TaskFreeCtx::idle();
             }

--- a/redGrapes/TaskCtx.hpp
+++ b/redGrapes/TaskCtx.hpp
@@ -35,7 +35,7 @@ namespace redGrapes
             }
             else
             {
-                event->waker_id = -2;
+                event->waker_id = parserID;
                 while(!event->is_reached())
                     TaskFreeCtx::idle();
             }

--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -21,6 +21,13 @@ namespace redGrapes
 
     using WorkerId = unsigned;
 
+    /** WorkerID of parser to wake it up
+     * ID 0,1,2... are used for worker threads
+     * ID -1 is used as the default value for WorkerId, indicating uninitialized/no workers
+     * Using the magic number -2 for the parser thread
+     */
+    constexpr WorkerId parserID = -2;
+
     // seperated to not templatize allocators with Task type
     struct WorkerAllocPool
     {

--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -9,6 +9,7 @@
 
 #include "redGrapes/memory/chunked_bump_alloc.hpp"
 #include "redGrapes/memory/hwloc_alloc.hpp"
+#include "redGrapes/sync/cv.hpp"
 
 #include <functional>
 #include <memory>
@@ -39,8 +40,19 @@ namespace redGrapes
         static inline unsigned n_pus;
         static inline HwlocContext hwloc_ctx;
         static inline std::shared_ptr<WorkerAllocPool> worker_alloc_pool;
+        static inline CondVar cv{0};
 
-        static inline thread_local std::function<void()> idle = [] {};
+        static inline std::function<void()> idle = []
+        {
+            SPDLOG_TRACE("Parser::idle()");
+
+            /* the main thread shall not do any busy waiting
+             * and always sleep right away in order to
+             * not block any worker threads (those however should
+             * busy-wait to improve latency)
+             */
+            cv.wait();
+        };
         static inline thread_local std::optional<WorkerId> current_worker_id;
     };
 } // namespace redGrapes

--- a/redGrapes/dispatch/cuda/cuda_worker.hpp
+++ b/redGrapes/dispatch/cuda/cuda_worker.hpp
@@ -79,11 +79,6 @@ namespace redGrapes::dispatch::cuda
         {
         }
 
-        inline scheduler::WakerId get_waker_id()
-        {
-            return id + 1;
-        }
-
         inline bool wake()
         {
             return cv.notify();
@@ -133,7 +128,7 @@ namespace redGrapes::dispatch::cuda
 
             if(event)
             {
-                event->get_event().waker_id = get_waker_id();
+                event->get_event().waker_id = id;
                 task.sg_pause(*event);
 
                 task.pre_event.up();
@@ -153,7 +148,7 @@ namespace redGrapes::dispatch::cuda
             SPDLOG_TRACE("Worker {} start work_loop()", this->id);
             while(!this->m_stop.load(std::memory_order_consume))
             {
-                // this->cv.wait(); // TODO fix this by fixing event_ptr notify to wake
+                // this->cv.wait(); // TODO fix this by only waiting if event_pool is empty
 
                 while(TTask* task = this->gather_task())
                 {

--- a/redGrapes/dispatch/mpi/mpiWorker.hpp
+++ b/redGrapes/dispatch/mpi/mpiWorker.hpp
@@ -49,11 +49,6 @@ namespace redGrapes
                 {
                 }
 
-                inline scheduler::WakerId get_waker_id()
-                {
-                    return id + 1;
-                }
-
                 inline bool wake()
                 {
                     return cv.notify();
@@ -89,7 +84,7 @@ namespace redGrapes
 
                     if(event)
                     {
-                        event->get_event().waker_id = get_waker_id();
+                        event->get_event().waker_id = id;
                         task.sg_pause(*event);
 
                         task.pre_event.up();
@@ -173,7 +168,7 @@ namespace redGrapes
                     SPDLOG_TRACE("Worker {} start work_loop()", this->id);
                     while(!this->m_stop.load(std::memory_order_consume))
                     {
-                        // this->cv.wait(); // TODO fix this by fixing event_ptr notify to wake
+                        // this->cv.wait(); // TODO fix this by only waiting if requestPool is empty
 
                         while(TTask* task = this->gather_task())
                         {

--- a/redGrapes/dispatch/thread/DefaultWorker.hpp
+++ b/redGrapes/dispatch/thread/DefaultWorker.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "redGrapes/scheduler/scheduler.hpp"
 #include "redGrapes/sync/cv.hpp"
 #include "redGrapes/task/queue.hpp"
 #include "redGrapes/util/bitfield.hpp"
@@ -66,11 +65,6 @@ namespace redGrapes
                 }
 
                 ~DefaultWorker();
-
-                inline scheduler::WakerId get_waker_id()
-                {
-                    return id + 1;
-                }
 
                 inline bool wake()
                 {

--- a/redGrapes/dispatch/thread/DefaultWorker.tpp
+++ b/redGrapes/dispatch/thread/DefaultWorker.tpp
@@ -69,7 +69,7 @@ namespace redGrapes
 
                 if(event)
                 {
-                    event->get_event().waker_id = get_waker_id();
+                    event->get_event().waker_id = id;
                     task.sg_pause(*event);
 
                     task.pre_event.up();

--- a/redGrapes/scheduler/event.tpp
+++ b/redGrapes/scheduler/event.tpp
@@ -148,7 +148,7 @@ namespace redGrapes
             assert(old_state > 0);
 
             // test for state == 0 is not strictly required as no one adds a follower to result set
-            if(this->tag == EventPtrTag::T_EVT_RES_SET && state == 0 && get_event().waker_id == -2)
+            if(this->tag == EventPtrTag::T_EVT_RES_SET && state == 0 && get_event().waker_id == parserID)
             {
                 TaskFreeCtx::cv.notify();
             }

--- a/redGrapes/scheduler/event.tpp
+++ b/redGrapes/scheduler/event.tpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/scheduler/event.hpp"
 #include "redGrapes/util/trace.hpp"
 
@@ -145,6 +146,12 @@ namespace redGrapes
                     state);
 
             assert(old_state > 0);
+
+            // test for state == 0 is not strictly required as no one adds a follower to result set
+            if(this->tag == EventPtrTag::T_EVT_RES_SET && state == 0 && get_event().waker_id == -2)
+            {
+                TaskFreeCtx::cv.notify();
+            }
 
             if(task)
             {

--- a/redGrapes/scheduler/pool_scheduler.hpp
+++ b/redGrapes/scheduler/pool_scheduler.hpp
@@ -7,11 +7,9 @@
 
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/dispatch/thread/worker_pool.hpp"
 #include "redGrapes/scheduler/scheduler.hpp"
-#include "redGrapes/sync/cv.hpp"
-
-#include <redGrapes/TaskFreeCtx.hpp>
 
 namespace redGrapes
 {
@@ -27,15 +25,12 @@ namespace redGrapes
         {
             using TTask = Worker::task_type;
             WorkerId m_base_id;
-            CondVar cv;
             WorkerId local_next_worker_id = 0;
             unsigned n_workers;
             std::shared_ptr<dispatch::thread::WorkerPool<Worker>> m_worker_pool;
 
             PoolScheduler(unsigned num_workers);
             PoolScheduler(std::shared_ptr<dispatch::thread::WorkerPool<Worker>> workerPool);
-
-            void idle();
 
             /* send the new task to a worker
              */
@@ -49,14 +44,13 @@ namespace redGrapes
 
             /* Wakeup some worker or the main thread
              *
-             * WakerId = 0 for main thread
-             * WakerId = WorkerId + 1
+             * WakerId = WorkerId
              *
              * @return true if thread was indeed asleep
              */
             bool wake(WakerId id = 0);
 
-            /* wakeup all wakers (workers + main thread)
+            /* wakeup all workers
              */
             void wake_all();
 

--- a/redGrapes/scheduler/scheduler.hpp
+++ b/redGrapes/scheduler/scheduler.hpp
@@ -34,10 +34,6 @@ namespace redGrapes
                 return false;
             }
 
-            virtual void idle()
-            {
-            }
-
             //! add task to the set of to-initialize tasks
             virtual void emplace_task(TTask& task)
             {

--- a/redGrapes/sync/cv.hpp
+++ b/redGrapes/sync/cv.hpp
@@ -52,7 +52,7 @@ namespace redGrapes
             {
                 if(++count > timeout)
                 {
-                    // TODO: check this opmitization
+                    // TODO: check this opmitization with a member std::atomic_flag busy
                     // busy.clear(std::memory_order_release);
 
                     if(should_wait.load(std::memory_order_acquire))

--- a/redGrapes/util/trace.hpp
+++ b/redGrapes/util/trace.hpp
@@ -45,4 +45,4 @@ void StopTracing(std::shared_ptr<perfetto::TracingSession> tracing_session);
 
 #endif
 
-#include <redGrapes/util/trace.tpp>
+#include "redGrapes/util/trace.tpp"

--- a/redGrapes/util/trace.tpp
+++ b/redGrapes/util/trace.tpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <redGrapes/util/trace.hpp>
+#include "redGrapes/util/trace.hpp"
 
 #if REDGRAPES_ENABLE_TRACE
 


### PR DESCRIPTION
Fix the parser thread idle. Now it sleeps instantly when `idle()` is called, instead of busy waiting.
Also change wakerID being workerID + 1. Now they are the same.