### PR TITLE
Make next worker atomic

### DIFF
--- a/redGrapes/scheduler/pool_scheduler.hpp
+++ b/redGrapes/scheduler/pool_scheduler.hpp
@@ -25,7 +25,6 @@ namespace redGrapes
         {
             using TTask = Worker::task_type;
             WorkerId m_base_id;
-            WorkerId local_next_worker_id = 0;
             unsigned n_workers;
             std::shared_ptr<dispatch::thread::WorkerPool<Worker>> m_worker_pool;
 

--- a/redGrapes/scheduler/pool_scheduler.tpp
+++ b/redGrapes/scheduler/pool_scheduler.tpp
@@ -121,10 +121,8 @@ namespace redGrapes
         template<typename Worker>
         unsigned PoolScheduler<Worker>::getNextWorkerID()
         {
-            // TODO make atomic
-            auto id = local_next_worker_id + m_base_id;
-            local_next_worker_id = (local_next_worker_id + 1) % n_workers;
-            return id;
+            static std::atomic<WorkerId> local_next_worker_counter = 0;
+            return (local_next_worker_counter++ % n_workers) + m_base_id;
         }
 
         template<typename Worker>


### PR DESCRIPTION
Emplace task might be called in simultaneously when creating child tasks, so, made getNextWorkerID thread safe by using an atomic counter.
Fixes a race condition where multiple tasks may be emplaced to the same worker consecutively.