### PR TITLE
Fix child parent dependency

### DIFF
--- a/examples/8_child_destruction.cpp
+++ b/examples/8_child_destruction.cpp
@@ -1,0 +1,52 @@
+/* Copyright 2024 Tapish Narwal
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_OFF
+
+#include <redGrapes/redGrapes.hpp>
+#include <redGrapes/resource/ioresource.hpp>
+
+#include <iostream>
+
+int main()
+{
+    spdlog::set_level(spdlog::level::off);
+
+    auto rg = redGrapes::init(1);
+    auto a = rg.createIOResource<int>(1);
+
+    rg.emplace_task(
+          [&rg]([[maybe_unused]] auto a)
+          {
+              std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
+
+              rg.emplace_task(
+                  [&rg](auto a)
+                  {
+                      *a = 2;
+                      std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
+                  },
+                  a.write());
+              rg.emplace_task(
+                  [&rg](auto a)
+                  {
+                      *a = 3;
+                      std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
+                  },
+                  a.write());
+
+              *a = 4;
+              std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
+          },
+          a.write())
+        .enable_stack_switching();
+    rg.emplace_task(
+          [&rg]([[maybe_unused]] auto a)
+          { std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl; },
+          a.read())
+        .enable_stack_switching();
+}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,7 @@ set(EXAMPLE_NAMES
     5_access_demotion
     6_resource_scope
     7_event
+    8_child_destruction
     game_of_life
 )
 

--- a/redGrapes/task/property/graph.tpp
+++ b/redGrapes/task/property/graph.tpp
@@ -70,13 +70,6 @@ namespace redGrapes
                 }
             }
         }
-
-        // add dependency to parent
-        if(auto parent = this->space->parent)
-        {
-            SPDLOG_TRACE("add event dep to parent");
-            this->post_event.add_follower(parent->get_post_event());
-        }
     }
 
     template<typename TTask>
@@ -97,10 +90,6 @@ namespace redGrapes
     template<typename TTask>
     void GraphProperty<TTask>::add_dependency(TTask& preceding_task)
     {
-        // precedence graph
-        // in_edges.push_back(&preceding_task);
-
-        // scheduling graph
         auto preceding_event = task->scheduler_p->task_dependency_type(preceding_task, *task)
                                    ? preceding_task->get_pre_event()
                                    : preceding_task->get_post_event();
@@ -114,7 +103,6 @@ namespace redGrapes
     {
         // std::unique_lock< SpinLock > lock( post_event.followers_mutex );
 
-        //    for( auto follower : post_event.followers )
         for(auto it = post_event.followers.rbegin(); it != post_event.followers.rend(); ++it)
         {
             scheduler::EventPtr<TTask> follower = *it;

--- a/redGrapes/task/task_space.hpp
+++ b/redGrapes/task/task_space.hpp
@@ -50,7 +50,12 @@ namespace redGrapes
             ++task_count;
 
             if(parent)
+            {
                 assert(parent->is_superset_of(*task));
+                // add dependency to parent
+                SPDLOG_TRACE("add event dep to parent");
+                task->post_event.add_follower(parent->get_post_event());
+            }
 
             for(auto r = task->unique_resources.rbegin(); r != task->unique_resources.rend(); ++r)
             {


### PR DESCRIPTION
Fixed a bug where a parent task is destroyed before `init_graph` is called on child tasks.
Before this PR `init_graph` was adding the dependency from the child task to the post event of the parent.  But `init_graph` is only called when the child task is actually processed to be put into the ready queue. This leads to a situation where the parent task can be destroyed and its post event will be notified while the child tasks are still in the emplacement queue.
Moved adding the dependency to the parent task from the child task to `emplace_task`.
This moves some work from scheduling to emplacement.
 
