### PR TITLE
Hold worker instead of pointer to a worker in WorkerThread

### DIFF
--- a/redGrapes/dispatch/mpi/mpiWorker.hpp
+++ b/redGrapes/dispatch/mpi/mpiWorker.hpp
@@ -42,7 +42,7 @@ namespace redGrapes
 
                 MPIWorker(WorkerId worker_id) : id(worker_id)
                 {
-                    requestPool = std::make_shared<RequestPool<TTask>>();
+                    requestPool = memory::alloc_shared_bind<RequestPool<TTask>>(id);
                 }
 
                 ~MPIWorker()

--- a/redGrapes/dispatch/thread/WorkerThread.hpp
+++ b/redGrapes/dispatch/thread/WorkerThread.hpp
@@ -23,12 +23,11 @@ namespace redGrapes::dispatch::thread
         hwloc_obj_t const obj; // storing this vs calculating this as
         // hwloc_obj_t obj
         //     = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, this->id % TaskFreeCtx::n_pus);
-        std::shared_ptr<Worker> worker;
+        Worker worker;
 
         template<typename... Args>
-        WorkerThread(hwloc_obj_t const obj, Args&&... args) : obj{obj}
+        WorkerThread(hwloc_obj_t const obj, Args&&... args) : obj{obj}, worker{std::forward<Args>(args)...}
         {
-            worker = std::make_shared<Worker>(std::forward<Args>(args)...);
         }
 
         ~WorkerThread()
@@ -42,7 +41,7 @@ namespace redGrapes::dispatch::thread
 
         void stop()
         {
-            worker->stop();
+            worker.stop();
             thread.join();
         }
 
@@ -57,11 +56,11 @@ namespace redGrapes::dispatch::thread
 
             /* initialize thread-local variables
              */
-            *TaskFreeCtx::current_worker_id = worker->id;
+            *TaskFreeCtx::current_worker_id = worker.id;
 
             /* execute tasks until stop()
              */
-            worker->work_loop();
+            worker.work_loop();
 
             TaskFreeCtx::current_worker_id = std::nullopt;
 

--- a/redGrapes/dispatch/thread/worker_pool.hpp
+++ b/redGrapes/dispatch/thread/worker_pool.hpp
@@ -105,7 +105,7 @@ namespace redGrapes
                         {
                             // we have a candidate of a busy worker,
                             // now check its queue
-                            if(TTask* t = get_worker_thread(idx).worker->emplacement_queue.pop())
+                            if(TTask* t = get_worker_thread(idx).worker.emplacement_queue.pop())
                                 return t;
 
                             // otherwise check own queue again
@@ -136,7 +136,7 @@ namespace redGrapes
                         {
                             // we have a candidate of a busy worker,
                             // now check its queue
-                            if(TTask* t = get_worker_thread(idx).worker->ready_queue.pop())
+                            if(TTask* t = get_worker_thread(idx).worker.ready_queue.pop())
                                 return t;
 
                             // otherwise check own queue again

--- a/redGrapes/scheduler/cuda_thread_scheduler.hpp
+++ b/redGrapes/scheduler/cuda_thread_scheduler.hpp
@@ -72,7 +72,7 @@ namespace redGrapes
             cudaStream_t getCudaStreamIdx(unsigned idx) const
             {
                 assert(idx < num_streams);
-                return this->m_worker_thread->worker->streams[idx].cuda_stream;
+                return this->m_worker_thread->worker.streams[idx].cuda_stream;
             }
 
             /**
@@ -85,7 +85,7 @@ namespace redGrapes
                 static std::atomic_uint stream_idx = 0;
                 auto task_stream_idx = stream_idx.fetch_add(1) % num_streams;
                 TaskCtx<TTask>::current_task->m_cuda_stream_idx = task_stream_idx;
-                return this->m_worker_thread->worker->streams[task_stream_idx].cuda_stream;
+                return this->m_worker_thread->worker.streams[task_stream_idx].cuda_stream;
             }
         };
     } // namespace scheduler

--- a/redGrapes/scheduler/mpi_thread_scheduler.hpp
+++ b/redGrapes/scheduler/mpi_thread_scheduler.hpp
@@ -24,7 +24,7 @@ namespace redGrapes
             // if worker is  MPI worker
             std::shared_ptr<dispatch::mpi::RequestPool<TTask>> getRequestPool()
             {
-                return this->m_worker_thread->worker->requestPool;
+                return this->m_worker_thread->worker.requestPool;
             }
         };
 

--- a/redGrapes/scheduler/pool_scheduler.tpp
+++ b/redGrapes/scheduler/pool_scheduler.tpp
@@ -39,7 +39,7 @@ namespace redGrapes
             // TODO: properly store affinity information in task
             WorkerId local_worker_id = task.worker_id - m_base_id;
 
-            m_worker_pool->get_worker_thread(local_worker_id).worker->dispatch_task(task);
+            m_worker_pool->get_worker_thread(local_worker_id).worker.dispatch_task(task);
 
             /* hack as of 2023/11/17
              *
@@ -56,7 +56,7 @@ namespace redGrapes
             auto id = m_worker_pool->probe_worker_by_state<unsigned>(
                 [&m_worker_pool](unsigned idx)
                 {
-                    m_worker_pool->get_worker_thread(idx).worker->wake();
+                    m_worker_pool->get_worker_thread(idx).worker.wake();
                     return idx;
                 },
                 dispatch::thread::WorkerState::AVAILABLE,
@@ -87,9 +87,9 @@ namespace redGrapes
                     worker_id = next_worker.fetch_add(1) % n_workers;
             }
 
-            m_worker_pool->get_worker_thread(worker_id).worker->ready_queue.push(&task);
+            m_worker_pool->get_worker_thread(worker_id).worker.ready_queue.push(&task);
             m_worker_pool->set_worker_state(worker_id, dispatch::thread::WorkerState::BUSY);
-            m_worker_pool->get_worker_thread(worker_id).worker->wake();
+            m_worker_pool->get_worker_thread(worker_id).worker.wake();
         }
 
         /* Wakeup some worker or the main thread
@@ -104,7 +104,7 @@ namespace redGrapes
             auto local_waker_id = id - m_base_id;
             // TODO analyse and optimize
             if(local_waker_id > 0 && local_waker_id <= n_workers)
-                return m_worker_pool->get_worker_thread(local_waker_id).worker->wake();
+                return m_worker_pool->get_worker_thread(local_waker_id).worker.wake();
             else
                 return false;
         }

--- a/redGrapes/scheduler/thread_scheduler.hpp
+++ b/redGrapes/scheduler/thread_scheduler.hpp
@@ -42,7 +42,7 @@ namespace redGrapes
             void emplace_task(TTask& task)
             {
                 // todo: properly store affinity information in task
-                m_worker_thread->worker->dispatch_task(task);
+                m_worker_thread->worker.dispatch_task(task);
             }
 
             /* send this already existing,
@@ -55,8 +55,8 @@ namespace redGrapes
                 TRACE_EVENT("Scheduler", "activate_task");
                 SPDLOG_TRACE("ThreadScheduler::activate_task({})", task.task_id);
 
-                m_worker_thread->worker->ready_queue.push(&task);
-                m_worker_thread->worker->wake();
+                m_worker_thread->worker.ready_queue.push(&task);
+                m_worker_thread->worker.wake();
             }
 
             /* Wakeup some worker or the main thread
@@ -69,7 +69,7 @@ namespace redGrapes
             {
                 // TODO remove this if else
                 if(id == 0)
-                    return m_worker_thread->worker->wake();
+                    return m_worker_thread->worker.wake();
                 else
                     return false;
             }
@@ -78,7 +78,7 @@ namespace redGrapes
              */
             void wake_all()
             {
-                m_worker_thread->worker->wake();
+                m_worker_thread->worker.wake();
             }
 
             unsigned getNextWorkerID()


### PR DESCRIPTION
Hold worker instead of pointer to a worker in WorkerThread
Use alloc_shared_bind for the MPI_request_pool instead of make_shared