### PR TITLE
Refactor Task to make it smaller

### DIFF
--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -43,9 +43,9 @@ namespace redGrapes
 
     struct TaskFreeCtx
     {
-        static inline unsigned n_workers;
-        static inline unsigned n_pus;
         static inline HwlocContext hwloc_ctx;
+        static inline uint8_t n_pus{static_cast<uint8_t>(hwloc_get_nbobjs_by_type(hwloc_ctx.topology, HWLOC_OBJ_PU))};
+        static inline unsigned n_workers;
         static inline std::shared_ptr<WorkerAllocPool> worker_alloc_pool;
         static inline CondVar cv{0};
 

--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -46,7 +46,7 @@ namespace redGrapes
         static inline HwlocContext hwloc_ctx;
         static inline uint8_t n_pus{static_cast<uint8_t>(hwloc_get_nbobjs_by_type(hwloc_ctx.topology, HWLOC_OBJ_PU))};
         static inline unsigned n_workers;
-        static inline std::shared_ptr<WorkerAllocPool> worker_alloc_pool;
+        static inline WorkerAllocPool worker_alloc_pool;
         static inline CondVar cv{0};
 
         static inline std::function<void()> idle = []

--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -11,15 +11,15 @@
 #include "redGrapes/memory/hwloc_alloc.hpp"
 #include "redGrapes/sync/cv.hpp"
 
+#include <cstdint>
 #include <functional>
-#include <memory>
 #include <optional>
 #include <vector>
 
 namespace redGrapes
 {
 
-    using WorkerId = unsigned;
+    using WorkerId = uint8_t;
 
     /** WorkerID of parser to wake it up
      * ID 0,1,2... are used for worker threads
@@ -44,8 +44,9 @@ namespace redGrapes
     struct TaskFreeCtx
     {
         static inline HwlocContext hwloc_ctx;
-        static inline uint8_t n_pus{static_cast<uint8_t>(hwloc_get_nbobjs_by_type(hwloc_ctx.topology, HWLOC_OBJ_PU))};
-        static inline unsigned n_workers;
+        static inline WorkerId n_pus{
+            static_cast<WorkerId>(hwloc_get_nbobjs_by_type(hwloc_ctx.topology, HWLOC_OBJ_PU))};
+        static inline WorkerId n_workers;
         static inline WorkerAllocPool worker_alloc_pool;
         static inline CondVar cv{0};
 

--- a/redGrapes/dispatch/thread/worker_pool.hpp
+++ b/redGrapes/dispatch/thread/worker_pool.hpp
@@ -76,7 +76,7 @@ namespace redGrapes
                 inline std::optional<T> probe_worker_by_state(
                     F&& f,
                     bool expected_worker_state,
-                    unsigned start_worker_idx,
+                    WorkerId start_worker_idx,
                     bool exclude_start = true)
                 {
                     return worker_state.template probe_by_value<T, F>(
@@ -100,7 +100,7 @@ namespace redGrapes
                 TTask* steal_new_task(Worker& worker)
                 {
                     std::optional<TTask*> task = probe_worker_by_state<TTask*>(
-                        [&worker, this](unsigned idx) -> std::optional<TTask*>
+                        [&worker, this](WorkerId idx) -> std::optional<TTask*>
                         {
                             // we have a candidate of a busy worker,
                             // now check its queue
@@ -131,7 +131,7 @@ namespace redGrapes
                 TTask* steal_ready_task(Worker& worker)
                 {
                     std::optional<TTask*> task = probe_worker_by_state<TTask*>(
-                        [&worker, this](unsigned idx) -> std::optional<TTask*>
+                        [&worker, this](WorkerId idx) -> std::optional<TTask*>
                         {
                             // we have a candidate of a busy worker,
                             // now check its queue
@@ -160,7 +160,7 @@ namespace redGrapes
                 // @return task if a new task was found, nullptr otherwise
                 TTask* steal_task(Worker& worker)
                 {
-                    unsigned local_worker_id = worker.id - m_base_id;
+                    WorkerId local_worker_id = worker.id - m_base_id;
 
                     SPDLOG_DEBUG("steal task for worker {}", local_worker_id);
 
@@ -189,7 +189,7 @@ namespace redGrapes
             private:
                 std::vector<std::shared_ptr<dispatch::thread::WorkerThread<Worker>>> workers;
                 AtomicBitfield worker_state;
-                unsigned int num_workers;
+                WorkerId num_workers;
                 WorkerId m_base_id;
             };
 

--- a/redGrapes/dispatch/thread/worker_pool.hpp
+++ b/redGrapes/dispatch/thread/worker_pool.hpp
@@ -188,7 +188,6 @@ namespace redGrapes
 
             private:
                 std::vector<std::shared_ptr<dispatch::thread::WorkerThread<Worker>>> workers;
-                HwlocContext* hwloc_ctx_p;
                 AtomicBitfield worker_state;
                 unsigned int num_workers;
                 WorkerId m_base_id;

--- a/redGrapes/dispatch/thread/worker_pool.tpp
+++ b/redGrapes/dispatch/thread/worker_pool.tpp
@@ -42,7 +42,7 @@ namespace redGrapes
                 SPDLOG_DEBUG("populate WorkerPool with {} workers", num_workers);
                 for(size_t worker_id = base_id; worker_id < base_id + num_workers; ++worker_id)
                 {
-                    unsigned pu_id = worker_id % TaskFreeCtx::n_pus;
+                    WorkerId pu_id = worker_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
                     TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(
@@ -82,12 +82,12 @@ namespace redGrapes
 
                 SPDLOG_TRACE("find worker...");
 
-                unsigned start_idx = 0;
+                WorkerId start_idx = 0;
                 if(TaskFreeCtx::current_worker_id)
                     start_idx = *TaskFreeCtx::current_worker_id - m_base_id;
 
-                std::optional<unsigned> idx = this->probe_worker_by_state<unsigned>(
-                    [this](unsigned idx) -> std::optional<unsigned>
+                std::optional<WorkerId> idx = this->probe_worker_by_state<WorkerId>(
+                    [this](WorkerId idx) -> std::optional<WorkerId>
                     {
                         if(set_worker_state(idx, WorkerState::BUSY))
                             return idx;

--- a/redGrapes/dispatch/thread/worker_pool.tpp
+++ b/redGrapes/dispatch/thread/worker_pool.tpp
@@ -45,7 +45,7 @@ namespace redGrapes
                     unsigned pu_id = worker_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
-                    TaskFreeCtx::worker_alloc_pool->allocs.emplace_back(
+                    TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(
                         memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
                         REDGRAPES_ALLOC_CHUNKSIZE);
 

--- a/redGrapes/memory/allocator.hpp
+++ b/redGrapes/memory/allocator.hpp
@@ -34,12 +34,12 @@ namespace redGrapes
 
             Block allocate(size_t n_bytes)
             {
-                return TaskFreeCtx::worker_alloc_pool->get_alloc(worker_id).allocate(n_bytes);
+                return TaskFreeCtx::worker_alloc_pool.get_alloc(worker_id).allocate(n_bytes);
             }
 
             void deallocate(Block blk)
             {
-                TaskFreeCtx::worker_alloc_pool->get_alloc(worker_id).deallocate(blk);
+                TaskFreeCtx::worker_alloc_pool.get_alloc(worker_id).deallocate(blk);
             }
         };
 

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -54,8 +54,7 @@ namespace redGrapes
                     TaskFreeCtx::n_workers,
                     TaskFreeCtx::n_pus);
 
-            TaskFreeCtx::worker_alloc_pool = std::make_shared<WorkerAllocPool>();
-            TaskFreeCtx::worker_alloc_pool->allocs.reserve(TaskFreeCtx::n_workers);
+            TaskFreeCtx::worker_alloc_pool.allocs.reserve(TaskFreeCtx::n_workers);
 
             TaskCtx<RGTask>::root_space = std::make_shared<TaskSpace<RGTask>>();
 

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -63,7 +63,7 @@ namespace redGrapes
                 scheduler->init(base_worker_id);
                 base_worker_id = base_worker_id + scheduler->n_workers;
             };
-            unsigned base_worker_id = 0;
+            WorkerId base_worker_id = 0;
             std::apply(
                 [&base_worker_id, initAdd](auto... args) { ((initAdd(args.scheduler, base_worker_id)), ...); },
                 execDescTuple);

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -48,7 +48,6 @@ namespace redGrapes
             TaskFreeCtx::n_workers
                 = std::apply([](auto... args) { return (args.scheduler->n_workers + ...); }, execDescTuple);
 
-            TaskFreeCtx::n_pus = hwloc_get_nbobjs_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU);
             if(TaskFreeCtx::n_workers > TaskFreeCtx::n_pus)
                 SPDLOG_WARN(
                     "{} worker-threads requested, but only {} PUs available!",

--- a/redGrapes/resource/resource.hpp
+++ b/redGrapes/resource/resource.hpp
@@ -48,19 +48,18 @@ namespace redGrapes
         }
 
     public:
-        unsigned int id;
-        unsigned int scope_level;
-
-        SpinLock users_mutex;
         ChunkedList<TTask*, REDGRAPES_RUL_CHUNKSIZE> users;
+        SpinLock users_mutex;
+        uint16_t id;
+        uint8_t scope_level;
 
         /**
          * Create a new resource with an unused ID.
          */
         ResourceBase()
-            : id(generateID())
+            : users(memory::Allocator(get_arena_id()))
+            , id(generateID())
             , scope_level(TaskCtx<TTask>::scope_depth())
-            , users(memory::Allocator(get_arena_id()))
         {
         }
 
@@ -267,7 +266,7 @@ namespace redGrapes
 
             Access(Access&& other)
                 : ResourceAccess<TTask>::AccessBase(
-                    std::move(std::forward<ResourceAccess<TTask>::AccessBase>(other))) // TODO check this
+                      std::move(std::forward<ResourceAccess<TTask>::AccessBase>(other))) // TODO check this
                 , policy(std::move(other.policy))
             {
             }

--- a/redGrapes/resource/resource.hpp
+++ b/redGrapes/resource/resource.hpp
@@ -41,9 +41,9 @@ namespace redGrapes
     class ResourceBase
     {
     protected:
-        static unsigned int generateID()
+        static uint16_t generateID()
         {
-            static std::atomic<unsigned int> id_counter;
+            static std::atomic<uint16_t> id_counter;
             return id_counter.fetch_add(1);
         }
 
@@ -63,7 +63,7 @@ namespace redGrapes
         {
         }
 
-        unsigned get_arena_id() const
+        WorkerId get_arena_id() const
         {
             return id % TaskFreeCtx::n_workers;
         }
@@ -321,10 +321,10 @@ namespace redGrapes
     public:
         Resource()
         {
-            static unsigned i = 0;
+            static WorkerId i = 0;
 
-            WorkerId worker_id = i++ % TaskFreeCtx::n_workers;
-            base = redGrapes::memory::alloc_shared_bind<ResourceBase<TTask>>(worker_id);
+            i = i++ % TaskFreeCtx::n_workers;
+            base = redGrapes::memory::alloc_shared_bind<ResourceBase<TTask>>(i);
         }
 
         /**

--- a/redGrapes/resource/resource.hpp
+++ b/redGrapes/resource/resource.hpp
@@ -34,6 +34,8 @@
 namespace redGrapes
 {
 
+    using ResourceID = uint16_t;
+
     template<typename TTask, typename AccessPolicy>
     class Resource;
 
@@ -41,16 +43,16 @@ namespace redGrapes
     class ResourceBase
     {
     protected:
-        static uint16_t generateID()
+        static ResourceID generateID()
         {
-            static std::atomic<uint16_t> id_counter;
+            static std::atomic<ResourceID> id_counter;
             return id_counter.fetch_add(1);
         }
 
     public:
         ChunkedList<TTask*, REDGRAPES_RUL_CHUNKSIZE> users;
         SpinLock users_mutex;
-        uint16_t id;
+        ResourceID id;
         uint8_t scope_level;
 
         /**
@@ -157,7 +159,7 @@ namespace redGrapes
             return this->obj->resource->scope_level;
         }
 
-        unsigned int resource_id() const
+        ResourceID resource_id() const
         {
             return this->obj->resource->id;
         }
@@ -321,7 +323,7 @@ namespace redGrapes
     public:
         Resource()
         {
-            static WorkerId i = 0;
+            static ResourceID i = 0;
 
             i = i++ % TaskFreeCtx::n_workers;
             base = redGrapes::memory::alloc_shared_bind<ResourceBase<TTask>>(i);

--- a/redGrapes/resource/resource_user.hpp
+++ b/redGrapes/resource/resource_user.hpp
@@ -65,10 +65,9 @@ namespace redGrapes
             return false;
         }
 
-        uint8_t scope_level;
-
         ChunkedList<ResourceAccess<TTask>, 8> access_list;
         ChunkedList<ResourceUsageEntry<TTask>, 8> unique_resources;
+        uint8_t scope_level;
     }; // struct ResourceUser
 
 } // namespace redGrapes

--- a/redGrapes/scheduler/cuda_thread_scheduler.hpp
+++ b/redGrapes/scheduler/cuda_thread_scheduler.hpp
@@ -39,7 +39,7 @@ namespace redGrapes
                     unsigned pu_id = base_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
-                    TaskFreeCtx::worker_alloc_pool->allocs.emplace_back(
+                    TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(
                         memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
                         REDGRAPES_ALLOC_CHUNKSIZE);
 

--- a/redGrapes/scheduler/cuda_thread_scheduler.hpp
+++ b/redGrapes/scheduler/cuda_thread_scheduler.hpp
@@ -36,7 +36,7 @@ namespace redGrapes
                 // TODO check if it was already initalized
                 if(!this->m_worker_thread)
                 {
-                    unsigned pu_id = base_id % TaskFreeCtx::n_pus;
+                    WorkerId pu_id = base_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
                     TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(

--- a/redGrapes/scheduler/event.hpp
+++ b/redGrapes/scheduler/event.hpp
@@ -40,9 +40,9 @@ namespace redGrapes
         template<typename TTask>
         struct EventPtr
         {
-            enum EventPtrTag tag;
-            TTask* task;
             std::shared_ptr<Event<TTask>> external_event;
+            TTask* task;
+            enum EventPtrTag tag = T_UNINITIALIZED;
 
             inline bool operator==(EventPtr<TTask> const& other) const
             {
@@ -84,16 +84,16 @@ namespace redGrapes
         template<typename TTask>
         struct Event
         {
+            //! the set of subsequent events
+            ChunkedList<EventPtr<TTask>, REDGRAPES_EVENT_FOLLOWER_LIST_CHUNKSIZE> followers;
+
             /*! number of incoming edges
              * state == 0: event is reached and can be removed
              */
-            std::atomic_uint16_t state;
-
+            std::atomic<uint16_t> state;
             //! waker that is waiting for this event
             WakerId waker_id;
 
-            //! the set of subsequent events
-            ChunkedList<EventPtr<TTask>, REDGRAPES_EVENT_FOLLOWER_LIST_CHUNKSIZE> followers;
 
             Event();
             Event(Event&);

--- a/redGrapes/scheduler/pool_scheduler.hpp
+++ b/redGrapes/scheduler/pool_scheduler.hpp
@@ -25,10 +25,10 @@ namespace redGrapes
         {
             using TTask = Worker::task_type;
             WorkerId m_base_id;
-            unsigned n_workers;
+            WorkerId n_workers;
             dispatch::thread::WorkerPool<Worker> m_worker_pool;
 
-            PoolScheduler(unsigned num_workers);
+            PoolScheduler(WorkerId num_workers);
             PoolScheduler(dispatch::thread::WorkerPool<Worker> workerPool);
 
             /* send the new task to a worker
@@ -53,7 +53,7 @@ namespace redGrapes
              */
             void wake_all();
 
-            unsigned getNextWorkerID();
+            WorkerId getNextWorkerID();
 
             void init(WorkerId base_id);
 

--- a/redGrapes/scheduler/pool_scheduler.hpp
+++ b/redGrapes/scheduler/pool_scheduler.hpp
@@ -26,10 +26,10 @@ namespace redGrapes
             using TTask = Worker::task_type;
             WorkerId m_base_id;
             unsigned n_workers;
-            std::shared_ptr<dispatch::thread::WorkerPool<Worker>> m_worker_pool;
+            dispatch::thread::WorkerPool<Worker> m_worker_pool;
 
             PoolScheduler(unsigned num_workers);
-            PoolScheduler(std::shared_ptr<dispatch::thread::WorkerPool<Worker>> workerPool);
+            PoolScheduler(dispatch::thread::WorkerPool<Worker> workerPool);
 
             /* send the new task to a worker
              */

--- a/redGrapes/scheduler/pool_scheduler.tpp
+++ b/redGrapes/scheduler/pool_scheduler.tpp
@@ -19,14 +19,13 @@ namespace redGrapes
     namespace scheduler
     {
         template<typename Worker>
-        PoolScheduler<Worker>::PoolScheduler(unsigned num_workers)
-            : n_workers(num_workers)
-            , m_worker_pool(std::make_shared<dispatch::thread::WorkerPool<Worker>>(num_workers))
+        PoolScheduler<Worker>::PoolScheduler(unsigned num_workers) : n_workers(num_workers)
+                                                                   , m_worker_pool(num_workers)
         {
         }
 
         template<typename Worker>
-        PoolScheduler<Worker>::PoolScheduler(std::shared_ptr<dispatch::thread::WorkerPool<Worker>> workerPool)
+        PoolScheduler<Worker>::PoolScheduler(dispatch::thread::WorkerPool<Worker> workerPool)
             : m_worker_pool(workerPool)
         {
         }
@@ -39,7 +38,7 @@ namespace redGrapes
             // TODO: properly store affinity information in task
             WorkerId local_worker_id = task.worker_id - m_base_id;
 
-            m_worker_pool->get_worker_thread(local_worker_id).worker.dispatch_task(task);
+            m_worker_pool.get_worker_thread(local_worker_id).worker.dispatch_task(task);
 
             /* hack as of 2023/11/17
              *
@@ -53,10 +52,10 @@ namespace redGrapes
 #endif
 
 #if REDGRAPES_EMPLACE_NOTIFY_NEXT
-            auto id = m_worker_pool->probe_worker_by_state<unsigned>(
+            auto id = m_worker_pool.probe_worker_by_state<unsigned>(
                 [&m_worker_pool](unsigned idx)
                 {
-                    m_worker_pool->get_worker_thread(idx).worker.wake();
+                    m_worker_pool.get_worker_thread(idx).worker.wake();
                     return idx;
                 },
                 dispatch::thread::WorkerState::AVAILABLE,
@@ -79,7 +78,7 @@ namespace redGrapes
             TRACE_EVENT("Scheduler", "activate_task");
             SPDLOG_TRACE("PoolScheduler::activate_task({})", task.task_id);
 
-            int worker_id = m_worker_pool->find_free_worker();
+            int worker_id = m_worker_pool.find_free_worker();
             if(worker_id < 0)
             {
                 worker_id = next_worker.fetch_add(1) % n_workers;
@@ -87,9 +86,9 @@ namespace redGrapes
                     worker_id = next_worker.fetch_add(1) % n_workers;
             }
 
-            m_worker_pool->get_worker_thread(worker_id).worker.ready_queue.push(&task);
-            m_worker_pool->set_worker_state(worker_id, dispatch::thread::WorkerState::BUSY);
-            m_worker_pool->get_worker_thread(worker_id).worker.wake();
+            m_worker_pool.get_worker_thread(worker_id).worker.ready_queue.push(&task);
+            m_worker_pool.set_worker_state(worker_id, dispatch::thread::WorkerState::BUSY);
+            m_worker_pool.get_worker_thread(worker_id).worker.wake();
         }
 
         /* Wakeup some worker or the main thread
@@ -104,7 +103,7 @@ namespace redGrapes
             auto local_waker_id = id - m_base_id;
             // TODO analyse and optimize
             if(local_waker_id > 0 && local_waker_id <= n_workers)
-                return m_worker_pool->get_worker_thread(local_waker_id).worker.wake();
+                return m_worker_pool.get_worker_thread(local_waker_id).worker.wake();
             else
                 return false;
         }
@@ -130,21 +129,21 @@ namespace redGrapes
         {
             // TODO check if it was already initalized
             m_base_id = base_id;
-            m_worker_pool->emplace_workers(m_base_id);
+            m_worker_pool.emplace_workers(m_base_id);
         }
 
         template<typename Worker>
         void PoolScheduler<Worker>::startExecution()
         {
             // TODO check if it was already started
-            m_worker_pool->start();
+            m_worker_pool.start();
         }
 
         template<typename Worker>
         void PoolScheduler<Worker>::stopExecution()
         {
             // TODO check if it was already stopped
-            m_worker_pool->stop();
+            m_worker_pool.stop();
         }
 
 

--- a/redGrapes/scheduler/scheduler.hpp
+++ b/redGrapes/scheduler/scheduler.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
+
 #include <spdlog/spdlog.h>
 
 namespace redGrapes
@@ -53,7 +55,7 @@ namespace redGrapes
                 return false;
             }
 
-            virtual unsigned getNextWorkerID()
+            virtual WorkerId getNextWorkerID()
             {
                 return 0;
             }

--- a/redGrapes/scheduler/thread_scheduler.hpp
+++ b/redGrapes/scheduler/thread_scheduler.hpp
@@ -95,7 +95,7 @@ namespace redGrapes
                     unsigned pu_id = base_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
-                    TaskFreeCtx::worker_alloc_pool->allocs.emplace_back(
+                    TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(
                         memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
                         REDGRAPES_ALLOC_CHUNKSIZE);
 

--- a/redGrapes/scheduler/thread_scheduler.hpp
+++ b/redGrapes/scheduler/thread_scheduler.hpp
@@ -26,7 +26,7 @@ namespace redGrapes
 
             WorkerId m_base_id;
             std::shared_ptr<dispatch::thread::WorkerThread<Worker>> m_worker_thread;
-            static constexpr unsigned n_workers = 1;
+            static constexpr WorkerId n_workers = 1;
 
             ThreadScheduler()
             {
@@ -81,7 +81,7 @@ namespace redGrapes
                 m_worker_thread->worker.wake();
             }
 
-            unsigned getNextWorkerID()
+            WorkerId getNextWorkerID()
             {
                 return m_base_id;
             }
@@ -92,7 +92,7 @@ namespace redGrapes
                 // TODO check if it was already initalized
                 if(!m_worker_thread)
                 {
-                    unsigned pu_id = base_id % TaskFreeCtx::n_pus;
+                    WorkerId pu_id = base_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
                     TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(

--- a/redGrapes/task/property/graph.hpp
+++ b/redGrapes/task/property/graph.hpp
@@ -77,22 +77,22 @@ namespace redGrapes
 
         inline scheduler::EventPtr<TTask> get_pre_event()
         {
-            return scheduler::EventPtr<TTask>{scheduler::T_EVT_PRE, this->task};
+            return scheduler::EventPtr<TTask>{nullptr, this->task, scheduler::T_EVT_PRE};
         }
 
         inline scheduler::EventPtr<TTask> get_post_event()
         {
-            return scheduler::EventPtr<TTask>{scheduler::T_EVT_POST, this->task};
+            return scheduler::EventPtr<TTask>{nullptr, this->task, scheduler::T_EVT_POST};
         }
 
         inline scheduler::EventPtr<TTask> get_result_set_event()
         {
-            return scheduler::EventPtr<TTask>{scheduler::T_EVT_RES_SET, this->task};
+            return scheduler::EventPtr<TTask>{nullptr, this->task, scheduler::T_EVT_RES_SET};
         }
 
         inline scheduler::EventPtr<TTask> get_result_get_event()
         {
-            return scheduler::EventPtr<TTask>{scheduler::T_EVT_RES_GET, this->task};
+            return scheduler::EventPtr<TTask>{nullptr, this->task, scheduler::T_EVT_RES_GET};
         }
 
         inline bool is_ready()
@@ -178,7 +178,7 @@ namespace redGrapes
             };
         };
 
-        void apply_patch(Patch const&){};
+        void apply_patch(Patch const&) {};
     };
 
 } // namespace redGrapes

--- a/redGrapes/task/property/graph.hpp
+++ b/redGrapes/task/property/graph.hpp
@@ -54,9 +54,6 @@ namespace redGrapes
 
         TTask* task;
 
-        //! number of parents
-        uint8_t scope_depth;
-
         //! task space that contains this task, must not be null
         std::shared_ptr<TaskSpace<TTask>> space;
 

--- a/redGrapes/task/property/graph.tpp
+++ b/redGrapes/task/property/graph.tpp
@@ -22,7 +22,7 @@ namespace redGrapes
     {
         auto event = memory::alloc_shared<scheduler::Event<TTask>>();
         event->add_follower(get_post_event());
-        return scheduler::EventPtr<TTask>{scheduler::T_EVT_EXT, task, event};
+        return scheduler::EventPtr<TTask>{event, task, scheduler::T_EVT_EXT};
     }
 
     /*!

--- a/redGrapes/task/property/id.hpp
+++ b/redGrapes/task/property/id.hpp
@@ -23,9 +23,9 @@ namespace redGrapes
     struct IDProperty
     {
     private:
-        static std::atomic_int& id_counter()
+        static std::atomic<TaskID>& id_counter()
         {
-            static std::atomic_int x;
+            static std::atomic<TaskID> x;
             return x;
         }
 

--- a/redGrapes/task/task.hpp
+++ b/redGrapes/task/task.hpp
@@ -46,7 +46,7 @@ namespace redGrapes
         }
 
         // worker id where task is first emplaced and task memory is located (may be stolen later)
-        uint16_t worker_id;
+        WorkerId worker_id;
         std::atomic<uint8_t> removal_countdown;
         scheduler::IScheduler<Task<UserTaskProperties...>>* scheduler_p;
 

--- a/redGrapes/task/task.hpp
+++ b/redGrapes/task/task.hpp
@@ -12,6 +12,7 @@
 #include "redGrapes/task/property/resource.hpp"
 #include "redGrapes/task/task_base.hpp"
 
+#include <cstdint>
 #include <type_traits>
 
 namespace redGrapes
@@ -29,15 +30,15 @@ namespace redGrapes
     struct Task
         : TaskBase<Task<UserTaskProperties...>>
         , TaskProperties1<
-              IDProperty,
-              ResourceProperty<Task<UserTaskProperties...>>,
               GraphProperty<Task<UserTaskProperties...>>,
+              ResourceProperty<Task<UserTaskProperties...>>,
+              IDProperty,
               UserTaskProperties...>
     {
         using TaskProperties = TaskProperties1<
-            IDProperty,
-            ResourceProperty<Task<UserTaskProperties...>>,
             GraphProperty<Task<UserTaskProperties...>>,
+            ResourceProperty<Task<UserTaskProperties...>>,
+            IDProperty,
             UserTaskProperties...>;
 
         virtual ~Task()
@@ -45,8 +46,8 @@ namespace redGrapes
         }
 
         // worker id where task is first emplaced and task memory is located (may be stolen later)
-        unsigned worker_id;
-        std::atomic_int removal_countdown;
+        uint16_t worker_id;
+        std::atomic<uint8_t> removal_countdown;
         scheduler::IScheduler<Task<UserTaskProperties...>>* scheduler_p;
 
         Task(scheduler::IScheduler<Task<UserTaskProperties...>>& scheduler)

--- a/redGrapes/task/task_space.hpp
+++ b/redGrapes/task/task_space.hpp
@@ -9,6 +9,7 @@
 
 #include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/memory/block.hpp"
+#include "redGrapes/task/property/id.hpp"
 #include "redGrapes/util/trace.hpp"
 
 #include <atomic>
@@ -22,7 +23,7 @@ namespace redGrapes
     template<typename TTask>
     struct TaskSpace : std::enable_shared_from_this<TaskSpace<TTask>>
     {
-        std::atomic<unsigned long> task_count;
+        std::atomic<TaskID> task_count;
         unsigned depth;
         TTask* parent;
 
@@ -64,7 +65,7 @@ namespace redGrapes
         void free_task(TTask* task)
         {
             TRACE_EVENT("TaskSpace", "free_task()");
-            unsigned count = task_count.fetch_sub(1) - 1;
+            TaskID count = task_count.fetch_sub(1) - 1;
 
             WorkerId worker_id = task->worker_id;
             task->~TTask();
@@ -90,7 +91,7 @@ namespace redGrapes
 
         bool empty() const
         {
-            unsigned tc = task_count.load();
+            TaskID tc = task_count.load();
             return tc == 0;
         }
     };

--- a/redGrapes/task/task_space.hpp
+++ b/redGrapes/task/task_space.hpp
@@ -66,7 +66,7 @@ namespace redGrapes
             TRACE_EVENT("TaskSpace", "free_task()");
             unsigned count = task_count.fetch_sub(1) - 1;
 
-            unsigned worker_id = task->worker_id;
+            WorkerId worker_id = task->worker_id;
             task->~TTask();
 
             // FIXME: len of the Block is not correct since FunTask object is bigger than sizeof(Task)

--- a/redGrapes/task/task_space.hpp
+++ b/redGrapes/task/task_space.hpp
@@ -70,7 +70,7 @@ namespace redGrapes
             task->~TTask();
 
             // FIXME: len of the Block is not correct since FunTask object is bigger than sizeof(Task)
-            TaskFreeCtx::worker_alloc_pool->get_alloc(worker_id).deallocate(
+            TaskFreeCtx::worker_alloc_pool.get_alloc(worker_id).deallocate(
                 memory::Block{(uintptr_t) task, sizeof(TTask)});
 
             // TODO: implement this using post-event of root-task?


### PR DESCRIPTION
Removed some unused variables
Moved things around in structs for better alignment
Pool scheduler now holds WorkerPool instead of pointer to it
n_pus is initialized earlier
The vector of allocators for each worker is now held as an object and not a pointer