### PR TITLE
Allocate memory explicity everywhere

### DIFF
--- a/examples/1_resources.cpp
+++ b/examples/1_resources.cpp
@@ -21,11 +21,12 @@ int main(int, char*[])
     redGrapes::ResourceUser<TTask> user1(
         {a.read(), // complete resource
          a.write().area({0}, {10}), // write only indices 0 to 10
-         b.write()});
+         b.write()},
+        0);
 
-    redGrapes::ResourceUser<TTask> user2({b.read()});
+    redGrapes::ResourceUser<TTask> user2({b.read()}, 0);
 
-    redGrapes::ResourceUser<TTask> user3({b.read(), c.write()});
+    redGrapes::ResourceUser<TTask> user3({b.read(), c.write()}, 0);
 
     std::cout << "is_serial(user1,user1) = " << is_serial(user1, user1) << std::endl;
     std::cout << "is_serial(user1,user2) = " << is_serial(user1, user2) << std::endl;

--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -20,6 +20,7 @@ namespace redGrapes
 {
 
     using WorkerId = uint8_t;
+    using ResourceId = uint16_t;
 
     /** WorkerID of parser to wake it up
      * ID 0,1,2... are used for worker threads
@@ -49,6 +50,12 @@ namespace redGrapes
         static inline WorkerId n_workers;
         static inline WorkerAllocPool worker_alloc_pool;
         static inline CondVar cv{0};
+
+        static inline ResourceId create_resource_uid()
+        {
+            static std::atomic<ResourceId> id = 0;
+            return id++;
+        }
 
         static inline std::function<void()> idle = []
         {

--- a/redGrapes/dispatch/mpi/request_pool.hpp
+++ b/redGrapes/dispatch/mpi/request_pool.hpp
@@ -77,12 +77,13 @@ namespace redGrapes
                  * yields until the request is done. While waiting
                  * for this request, other tasks will be executed.
                  *
+                 * Must be called inside a running task
                  * @param request The MPI request to wait for
                  * @return the resulting MPI status of the request
                  */
                 MPI_Status get_status(MPI_Request request)
                 {
-                    auto status = memory::alloc_shared<MPI_Status>();
+                    auto status = memory::alloc_shared_bind<MPI_Status>((*TaskCtx<TTask>::current_task)->worker_id);
                     auto event = *TaskCtx<TTask>::create_event();
 
                     // SPDLOG_TRACE("MPI RequestPool: status event = {}", (void*)event.get());

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -157,9 +157,7 @@ namespace redGrapes
                 throw std::bad_alloc();
 
             // construct task in-place
-            new(task) FunTask<Impl, RGTask>(*scheduler_map[TSchedTag{}]);
-
-            task->worker_id = worker_id;
+            new(task) FunTask<Impl, RGTask>(worker_id, *scheduler_map[TSchedTag{}]);
 
             return std::move(TaskBuilder<RGTask, Callable, Args...>(task, std::move(f), std::forward<Args>(args)...));
         }

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -188,7 +188,7 @@ namespace redGrapes
         template<typename Container, typename... Args>
         auto createFieldResource(Args&&... args) -> FieldResource<Container, RGTask>
         {
-            return FieldResource<Container, RGTask>(args...);
+            return FieldResource<Container, RGTask>(std::forward<Args>(args)...);
         }
 
         template<typename T>
@@ -200,13 +200,13 @@ namespace redGrapes
         template<typename T, typename... Args>
         auto createIOResource(Args&&... args) -> IOResource<T, RGTask>
         {
-            return IOResource<T, RGTask>(args...);
+            return IOResource<T, RGTask>(std::forward<Args>(args)...);
         }
 
         template<typename AccessPolicy>
         auto createResource() -> Resource<RGTask, AccessPolicy>
         {
-            return Resource<RGTask, AccessPolicy>();
+            return Resource<RGTask, AccessPolicy>(TaskFreeCtx::create_resource_uid());
         }
 
     private:

--- a/redGrapes/resource/resource_user.hpp
+++ b/redGrapes/resource/resource_user.hpp
@@ -42,9 +42,17 @@ namespace redGrapes
     template<typename TTask>
     struct ResourceUser
     {
-        ResourceUser();
-        ResourceUser(ResourceUser const& other);
-        ResourceUser(std::initializer_list<ResourceAccess<TTask>> list);
+        ResourceUser(WorkerId worker_id);
+        ResourceUser(ResourceUser const& other) = delete;
+
+        ResourceUser(ResourceUser<TTask> const& other, WorkerId worker_id)
+            : access_list(memory::Allocator(worker_id), other.access_list)
+            , unique_resources(memory::Allocator(worker_id), other.unique_resources)
+            , scope_level(other.scope_level)
+        {
+        }
+
+        ResourceUser(std::initializer_list<ResourceAccess<TTask>> list, WorkerId worker_id);
 
         void add_resource_access(ResourceAccess<TTask> ra);
         void rm_resource_access(ResourceAccess<TTask> ra);

--- a/redGrapes/resource/resource_user.tpp
+++ b/redGrapes/resource/resource_user.tpp
@@ -21,25 +21,17 @@ namespace redGrapes
     }
 
     template<typename TTask>
-    ResourceUser<TTask>::ResourceUser()
-        : access_list(memory::Allocator())
-        , unique_resources(memory::Allocator())
+    ResourceUser<TTask>::ResourceUser(WorkerId worker_id)
+        : access_list(memory::Allocator(worker_id))
+        , unique_resources(memory::Allocator(worker_id))
         , scope_level(TaskCtx<TTask>::scope_depth())
     {
     }
 
     template<typename TTask>
-    ResourceUser<TTask>::ResourceUser(ResourceUser<TTask> const& other)
-        : access_list(memory::Allocator(), other.access_list)
-        , unique_resources(memory::Allocator(), other.unique_resources)
-        , scope_level(other.scope_level)
-    {
-    }
-
-    template<typename TTask>
-    ResourceUser<TTask>::ResourceUser(std::initializer_list<ResourceAccess<TTask>> list)
-        : access_list(memory::Allocator())
-        , unique_resources(memory::Allocator())
+    ResourceUser<TTask>::ResourceUser(std::initializer_list<ResourceAccess<TTask>> list, WorkerId worker_id)
+        : access_list(memory::Allocator(worker_id))
+        , unique_resources(memory::Allocator(worker_id))
         , scope_level(TaskCtx<TTask>::scope_depth())
     {
         for(auto& ra : list)

--- a/redGrapes/scheduler/event.hpp
+++ b/redGrapes/scheduler/event.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/scheduler/scheduler.hpp"
 #include "redGrapes/util/chunked_list.hpp"
 
@@ -95,9 +96,9 @@ namespace redGrapes
             WakerId waker_id;
 
 
-            Event();
-            Event(Event&);
-            Event(Event&&);
+            Event(WorkerId worker_id);
+            Event(WorkerId worker_id, Event&);
+            Event(WorkerId worker_id, Event&&);
 
             bool is_reached();
             bool is_ready();

--- a/redGrapes/scheduler/event.tpp
+++ b/redGrapes/scheduler/event.tpp
@@ -20,25 +20,25 @@ namespace redGrapes
     namespace scheduler
     {
         template<typename TTask>
-        Event<TTask>::Event() : followers(memory::Allocator())
-                              , waker_id(-1)
-                              , state(1)
+        Event<TTask>::Event(WorkerId worker_id) : followers(memory::Allocator(worker_id))
+                                                , state(1)
+                                                , waker_id(-1)
         {
         }
 
         template<typename TTask>
-        Event<TTask>::Event(Event& other)
-            : followers(memory::Allocator())
-            , waker_id(other.waker_id)
+        Event<TTask>::Event(WorkerId worker_id, Event& other)
+            : followers(memory::Allocator(worker_id))
             , state((uint16_t) other.state)
+            , waker_id(other.waker_id)
         {
         }
 
         template<typename TTask>
-        Event<TTask>::Event(Event&& other)
-            : state((uint16_t) other.state)
+        Event<TTask>::Event(WorkerId worker_id, Event&& other)
+            : followers(memory::Allocator(worker_id))
+            , state((uint16_t) other.state)
             , waker_id(other.waker_id)
-            , followers(memory::Allocator())
         {
         }
 

--- a/redGrapes/task/future.hpp
+++ b/redGrapes/task/future.hpp
@@ -76,11 +76,11 @@ namespace redGrapes
     template<typename TTask>
     struct Future<void, TTask>
     {
-        Future(TTask& task) : task(task), taken(false)
+        Future(TTask& task) : taken(false), task(task)
         {
         }
 
-        Future(Future&& other) : task(other.task), taken(other.taken)
+        Future(Future&& other) : taken(other.taken), task(other.task)
         {
             SPDLOG_TRACE("MOVE future");
             other.taken = true;

--- a/redGrapes/task/property/graph.hpp
+++ b/redGrapes/task/property/graph.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/scheduler/event.hpp"
 
 #include <spdlog/spdlog.h>
@@ -42,6 +43,14 @@ namespace redGrapes
     template<typename TTask>
     struct GraphProperty
     {
+        GraphProperty(WorkerId worker_id)
+            : pre_event{worker_id}
+            , post_event{worker_id}
+            , result_set_event{worker_id}
+            , result_get_event{worker_id}
+        {
+        }
+
         TTask& operator*()
         {
             return *task;

--- a/redGrapes/task/property/graph.tpp
+++ b/redGrapes/task/property/graph.tpp
@@ -20,7 +20,8 @@ namespace redGrapes
     template<typename TTask>
     scheduler::EventPtr<TTask> GraphProperty<TTask>::make_event()
     {
-        auto event = memory::alloc_shared<scheduler::Event<TTask>>();
+        // create event on task->worker_id and pass it as arg also so event can create follower list on same worker
+        auto event = memory::alloc_shared_bind<scheduler::Event<TTask>>(task->worker_id, task->worker_id);
         event->add_follower(get_post_event());
         return scheduler::EventPtr<TTask>{event, task, scheduler::T_EVT_EXT};
     }

--- a/redGrapes/task/property/id.hpp
+++ b/redGrapes/task/property/id.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
+
 #include <fmt/format.h>
 
 #include <atomic>
@@ -32,15 +34,15 @@ namespace redGrapes
     public:
         TaskID task_id;
 
-        IDProperty() : task_id(-1) // id_counter().fetch_add( 1, std::memory_order_seq_cst ) )
+        IDProperty(WorkerId) : task_id(-1) // id_counter().fetch_add( 1, std::memory_order_seq_cst ) )
         {
         }
 
-        IDProperty(IDProperty&& other) : task_id(other.task_id)
+        IDProperty(WorkerId, IDProperty&& other) : task_id(other.task_id)
         {
         }
 
-        IDProperty(IDProperty const& other) : task_id(other.task_id)
+        IDProperty(WorkerId, IDProperty const& other) : task_id(other.task_id)
         {
         }
 
@@ -75,7 +77,7 @@ namespace redGrapes
             };
         };
 
-        void apply_patch(Patch const&){};
+        void apply_patch(Patch const&) {};
     };
 
 } // namespace redGrapes

--- a/redGrapes/task/property/inherit.hpp
+++ b/redGrapes/task/property/inherit.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/task/property/trait.hpp"
 
 #include <fmt/format.h>
@@ -24,6 +25,10 @@ namespace redGrapes
         : T_Head
         , TaskPropertiesInherit<T_Tail...>
     {
+        TaskPropertiesInherit(WorkerId worker_id) : TaskPropertiesInherit<T_Tail...>(worker_id), T_Head(worker_id)
+        {
+        }
+
         template<typename B>
         struct Builder
             : T_Head::template Builder<B>
@@ -65,6 +70,10 @@ namespace redGrapes
     template<>
     struct TaskPropertiesInherit<PropEnd_t>
     {
+        TaskPropertiesInherit(WorkerId)
+        {
+        }
+
         template<typename PropertiesBuilder>
         struct Builder
         {
@@ -92,6 +101,10 @@ namespace redGrapes
     template<typename... Policies>
     struct TaskProperties1 : public TaskPropertiesInherit<Policies..., PropEnd_t>
     {
+        TaskProperties1(WorkerId worker_id) : TaskPropertiesInherit<Policies..., PropEnd_t>(worker_id)
+        {
+        }
+
         template<typename B>
         struct Builder : TaskPropertiesInherit<Policies..., PropEnd_t>::template Builder<B>
         {

--- a/redGrapes/task/property/label.hpp
+++ b/redGrapes/task/property/label.hpp
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "redGrapes/memory/allocator.hpp"
+#include "redGrapes/TaskFreeCtx.hpp"
 
 #include <fmt/format.h>
 
@@ -22,9 +22,14 @@ namespace redGrapes
 
     struct LabelProperty
     {
-        using string = std::basic_string<char, std::char_traits<char>, memory::StdAllocator<char>>;
+        // TODO Optimization, use the workerId to allocate the label string seperate from the task
+        // using string = std::basic_string<char, std::char_traits<char>, memory::StdAllocator<char>>;
 
-        string label;
+        LabelProperty(WorkerId)
+        {
+        }
+
+        std::string label;
 
         template<typename TaskBuilder>
         struct Builder
@@ -35,7 +40,7 @@ namespace redGrapes
             {
             }
 
-            TaskBuilder& label(string const& l)
+            TaskBuilder& label(std::string const& l)
             {
                 builder.task->label = l;
                 return builder;

--- a/redGrapes/task/property/resource.hpp
+++ b/redGrapes/task/property/resource.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "redGrapes/TaskCtx.hpp"
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/resource/resource_user.hpp"
 
 #include <fmt/format.h>
@@ -25,6 +27,10 @@ namespace redGrapes
     template<typename TTask>
     struct ResourceProperty : ResourceUser<TTask>
     {
+        ResourceProperty(WorkerId worker_id) : ResourceUser<TTask>(worker_id)
+        {
+        }
+
         template<typename PropertiesBuilder>
         struct Builder
         {
@@ -112,9 +118,10 @@ namespace redGrapes
             this->rm_resource_access(ra);
         }
 
+        // Only to be called inside a running task to update property
         void apply_patch(Patch const& patch)
         {
-            ResourceUser before(*this);
+            ResourceUser before(*this, (*TaskCtx<TTask>::current_task)->worker_id);
 
             for(auto x : patch.diff)
             {

--- a/redGrapes/task/task.hpp
+++ b/redGrapes/task/task.hpp
@@ -48,8 +48,9 @@ namespace redGrapes
         std::atomic<uint8_t> removal_countdown;
         scheduler::IScheduler<Task<UserTaskProperties...>>* scheduler_p;
 
-        Task(WorkerId worker_id, scheduler::IScheduler<Task<UserTaskProperties...>>& scheduler)
-            : worker_id(worker_id)
+        Task(WorkerId _worker_id, scheduler::IScheduler<Task<UserTaskProperties...>>& scheduler)
+            : TaskProperties(_worker_id)
+            , worker_id(_worker_id)
             , removal_countdown(2)
             , scheduler_p(&scheduler)
         {

--- a/redGrapes/task/task.hpp
+++ b/redGrapes/task/task.hpp
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/task/property/graph.hpp"
 #include "redGrapes/task/property/id.hpp"
 #include "redGrapes/task/property/inherit.hpp"
@@ -47,8 +48,9 @@ namespace redGrapes
         std::atomic<uint8_t> removal_countdown;
         scheduler::IScheduler<Task<UserTaskProperties...>>* scheduler_p;
 
-        Task(scheduler::IScheduler<Task<UserTaskProperties...>>& scheduler)
-            : removal_countdown(2)
+        Task(WorkerId worker_id, scheduler::IScheduler<Task<UserTaskProperties...>>& scheduler)
+            : worker_id(worker_id)
+            , removal_countdown(2)
             , scheduler_p(&scheduler)
         {
         }
@@ -67,7 +69,7 @@ namespace redGrapes
     {
         Result result_data;
 
-        ResultTask(scheduler::IScheduler<TTask>& scheduler) : TTask(scheduler)
+        ResultTask(WorkerId worker_id, scheduler::IScheduler<TTask>& scheduler) : TTask(worker_id, scheduler)
         {
         }
 
@@ -92,7 +94,7 @@ namespace redGrapes
     template<typename TTask>
     struct ResultTask<void, TTask> : TTask
     {
-        ResultTask(scheduler::IScheduler<TTask>& scheduler) : TTask(scheduler)
+        ResultTask(WorkerId worker_id, scheduler::IScheduler<TTask>& scheduler) : TTask(worker_id, scheduler)
         {
         }
 
@@ -114,8 +116,8 @@ namespace redGrapes
     template<typename F, typename TTask>
     struct FunTask : ResultTask<typename std::invoke_result_t<F>, TTask>
     {
-        FunTask(scheduler::IScheduler<TTask>& scheduler)
-            : ResultTask<typename std::invoke_result_t<F>, TTask>(scheduler)
+        FunTask(WorkerId worker_id, scheduler::IScheduler<TTask>& scheduler)
+            : ResultTask<typename std::invoke_result_t<F>, TTask>(worker_id, scheduler)
         {
         }
 

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -46,7 +46,8 @@ TEST_CASE("Resource ID")
 {
     auto rg = redGrapes::init(1);
     using RGTask = decltype(rg)::RGTask;
-    redGrapes::Resource<RGTask, Access> a, b;
+    auto a = rg.createResource<Access>();
+    auto b = rg.createResource<Access>();
 
     // same resource
     REQUIRE(redGrapes::ResourceAccess<RGTask>::is_serial(a.make_access(Access{}), a.make_access(Access{})) == true);

--- a/test/resource_user.cpp
+++ b/test/resource_user.cpp
@@ -7,16 +7,16 @@
 
 TEST_CASE("Resource User")
 {
-    auto rg = redGrapes::init();
+    auto rg = redGrapes::init(1);
     using RGTask = decltype(rg)::RGTask;
 
     redGrapes::IOResource<int, RGTask> a, b;
 
-    redGrapes::ResourceUser<RGTask> f1({a.read()});
-    redGrapes::ResourceUser<RGTask> f2({a.read(), a.write()});
-    redGrapes::ResourceUser<RGTask> f3({b.read()});
-    redGrapes::ResourceUser<RGTask> f4({b.read(), b.write()});
-    redGrapes::ResourceUser<RGTask> f5({a.read(), a.write(), b.read(), b.write()});
+    redGrapes::ResourceUser<RGTask> f1({a.read()}, 0);
+    redGrapes::ResourceUser<RGTask> f2({a.read(), a.write()}, 0);
+    redGrapes::ResourceUser<RGTask> f3({b.read()}, 0);
+    redGrapes::ResourceUser<RGTask> f4({b.read(), b.write()}, 0);
+    redGrapes::ResourceUser<RGTask> f5({a.read(), a.write(), b.read(), b.write()}, 0);
 
     REQUIRE(is_serial(f1, f1) == false);
     REQUIRE(is_serial(f1, f2) == true);


### PR DESCRIPTION
Fixes the bug introduced in #58 where event follower lists and resource  access lists were not allocated at the right place. 
RedGrapes doesnt depend on global state for memory allocation anymore