### PR TITLE
Change how resource access and passing resource to task works

### DIFF
--- a/examples/1_resources.cpp
+++ b/examples/1_resources.cpp
@@ -6,6 +6,8 @@
  */
 
 #include <redGrapes/redGrapes.hpp>
+#include <redGrapes/resource/fieldresource.hpp>
+#include <redGrapes/resource/ioresource.hpp>
 
 #include <iostream>
 
@@ -13,13 +15,13 @@ int main(int, char*[])
 {
     auto rg = redGrapes::init(1);
 
-    auto a = rg.createFieldResource<std::vector<int>>();
-    auto b = rg.createIOResource<int>();
-    auto c = rg.createIOResource<int>();
+    auto a = redGrapes::FieldResource<std::vector<int>>();
+    auto b = redGrapes::IOResource<int>();
+    auto c = redGrapes::IOResource<int>();
 
     redGrapes::ResourceUser user1(
         {a.read(), // complete resource
-         a.write().area({0}, {10}), // write only indices 0 to 10
+         a.write({0}, {10}), // write only indices 0 to 10
          b.write()},
         0,
         0);

--- a/examples/3_functors_with_resources.cpp
+++ b/examples/3_functors_with_resources.cpp
@@ -17,8 +17,8 @@ int main(void)
     spdlog::set_level(spdlog::level::trace);
     auto rg = redGrapes::init();
 
-    auto a = rg.createIOResource<int>();
-    auto b = rg.createIOResource<int>();
+    auto a = redGrapes::IOResource<int>();
+    auto b = redGrapes::IOResource<int>();
 
     for(int i = 0; i < 1; ++i)
     {

--- a/examples/5_access_demotion.cpp
+++ b/examples/5_access_demotion.cpp
@@ -6,6 +6,8 @@
  */
 
 #include <redGrapes/redGrapes.hpp>
+#include <redGrapes/resource/access/io.hpp>
+#include <redGrapes/resource/resource.hpp>
 #include <redGrapes/resource/ioresource.hpp>
 
 #include <chrono>
@@ -28,8 +30,8 @@ int main(int, char*[])
 
             std::cout << "f1 now only reads A" << std::endl;
             rg.update_properties(decltype(rg)::RGTask::TaskProperties::Patch::Builder()
-                                     .remove_resources({a.write()})
-                                     .add_resources({a.read()}));
+                                     .remove_resources({a})
+                                     .add_resources({rg::newAccess(a, rg::access::IOAccess(rg::access::IOAccess::read))}));
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
             std::cout << "f1 done" << std::endl;

--- a/examples/5_access_demotion.cpp
+++ b/examples/5_access_demotion.cpp
@@ -7,8 +7,8 @@
 
 #include <redGrapes/redGrapes.hpp>
 #include <redGrapes/resource/access/io.hpp>
-#include <redGrapes/resource/resource.hpp>
 #include <redGrapes/resource/ioresource.hpp>
+#include <redGrapes/resource/resource.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -20,23 +20,26 @@ int main(int, char*[])
 {
     spdlog::set_level(spdlog::level::trace);
     auto rg = rg::init();
-    auto a = rg.createIOResource<int>();
+    auto a = redGrapes::IOResource<int>();
 
-    rg.emplace_task(
-        [&](auto a)
-        {
-            std::cout << "f1 writes A" << std::endl;
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+    // Access demotion is not implemented
 
-            std::cout << "f1 now only reads A" << std::endl;
-            rg.update_properties(decltype(rg)::RGTask::TaskProperties::Patch::Builder()
-                                     .remove_resources({a})
-                                     .add_resources({rg::newAccess(a, rg::access::IOAccess(rg::access::IOAccess::read))}));
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+    // rg.emplace_task(
+    //     [&](auto a)
+    //     {
+    //         std::cout << "f1 writes A" << std::endl;
+    //         std::this_thread::sleep_for(std::chrono::seconds(1));
 
-            std::cout << "f1 done" << std::endl;
-        },
-        a.write());
+    //         std::cout << "f1 now only reads A" << std::endl;
+    //         rg.update_properties(decltype(rg)::RGTask::TaskProperties::Patch::Builder()
+    //                                  .remove_resources({a})
+    //                                  .add_resources({rg::newAccess(a,
+    //                                  rg::access::IOAccess(rg::access::IOAccess::read))}));
+    //         std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    //         std::cout << "f1 done" << std::endl;
+    //     },
+    //     a.write());
 
     rg.emplace_task(
         []([[maybe_unused]] auto a)

--- a/examples/6_resource_scope.cpp
+++ b/examples/6_resource_scope.cpp
@@ -15,13 +15,13 @@ namespace rg = redGrapes;
 int main()
 {
     auto rg = rg::init(1);
-    auto a = rg.createIOResource<int>(); // scope-level=0
+    auto a = redGrapes::IOResource<int>(); // scope-level=0
 
     rg.emplace_task(
           [&]([[maybe_unused]] auto a)
           {
               std::cout << "scope = " << rg.scope_depth() << std::endl;
-              auto b = rg.createIOResource<int>(); // scope-level=1
+              auto b = redGrapes::IOResource<int>(); // scope-level=1
 
               rg.emplace_task(
                     [&](auto b)

--- a/examples/7_event.cpp
+++ b/examples/7_event.cpp
@@ -8,6 +8,7 @@
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_OFF
 
 #include <redGrapes/redGrapes.hpp>
+#include <redGrapes/resource/ioresource.hpp>
 
 #include <chrono>
 #include <iostream>

--- a/examples/8_child_destruction.cpp
+++ b/examples/8_child_destruction.cpp
@@ -30,14 +30,22 @@ int main()
                       *a = 2;
                       std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
                   },
-                  a.write());
+                  a);
               rg.emplace_task(
                   [&rg](auto a)
                   {
                       *a = 3;
                       std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
+                      auto b = redGrapes::IOResource(a.first);
+                      rg.emplace_task(
+                          [&rg](auto b)
+                          {
+                              std::cout << "scope = " << rg.scope_depth() << " a = " << *b << std::endl;
+                              *b = 4;
+                          },
+                          b.write());
                   },
-                  a.write());
+                  a);
 
               *a = 4;
               std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;

--- a/examples/8_child_destruction.cpp
+++ b/examples/8_child_destruction.cpp
@@ -17,35 +17,35 @@ int main()
     spdlog::set_level(spdlog::level::off);
 
     auto rg = redGrapes::init(1);
-    auto a = rg.createIOResource<int>(1);
+    auto a = redGrapes::IOResource<int>(1);
 
     rg.emplace_task(
           [&rg]([[maybe_unused]] auto a)
           {
               std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
-
+              auto a2 = redGrapes::IOResource(a);
               rg.emplace_task(
                   [&rg](auto a)
                   {
                       *a = 2;
                       std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
                   },
-                  a);
+                  a2.write());
               rg.emplace_task(
                   [&rg](auto a)
                   {
                       *a = 3;
                       std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
-                      auto b = redGrapes::IOResource(a.first);
+                      auto a3 = redGrapes::IOResource(a);
                       rg.emplace_task(
-                          [&rg](auto b)
+                          [&rg](auto a)
                           {
-                              std::cout << "scope = " << rg.scope_depth() << " a = " << *b << std::endl;
-                              *b = 4;
+                              std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;
+                              *a = 4;
                           },
-                          b.write());
+                          a3.write());
                   },
-                  a);
+                  a2.write());
 
               *a = 4;
               std::cout << "scope = " << rg.scope_depth() << " a = " << *a << std::endl;

--- a/examples/cholesky.cpp
+++ b/examples/cholesky.cpp
@@ -23,7 +23,7 @@ void print_matrix(std::vector<redGrapes::IOResource<double*>> A, int nblks, int 
             {
                 for(int jb = 0; jb < blocksize; ++jb)
                 {
-                    std::cout << (*A[ja * nblks + ia].read())[jb * blocksize + ib] << "; ";
+                    std::cout << (*A[ja * nblks + ia].getObject())[jb * blocksize + ib] << "; ";
                 }
             }
             std::cout << std::endl;
@@ -84,7 +84,8 @@ int main(int argc, char* argv[])
         for(size_t ib = 0; ib < blksz; ++ib)
             for(size_t ja = 0; ja < nblks; ++ja)
                 for(size_t jb = 0; jb < blksz; ++jb)
-                    (*A[ja * nblks + ia].write())[jb * blksz + ib] = Alin[(ia * blksz + ib) + (ja * blksz + jb) * N];
+                    (*A[ja * nblks + ia].getObject())[jb * blksz + ib]
+                        = Alin[(ia * blksz + ib) + (ja * blksz + jb) * N];
 
     print_matrix(A, nblks, blksz);
 

--- a/examples/cholesky.cpp
+++ b/examples/cholesky.cpp
@@ -23,7 +23,7 @@ void print_matrix(std::vector<redGrapes::IOResource<double*>> A, int nblks, int 
             {
                 for(int jb = 0; jb < blocksize; ++jb)
                 {
-                    std::cout << (*A[ja * nblks + ia])[jb * blocksize + ib] << "; ";
+                    std::cout << (*A[ja * nblks + ia].read())[jb * blocksize + ib] << "; ";
                 }
             }
             std::cout << std::endl;
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
         for(size_t ib = 0; ib < blksz; ++ib)
             for(size_t ja = 0; ja < nblks; ++ja)
                 for(size_t jb = 0; jb < blksz; ++jb)
-                    (*A[ja * nblks + ia])[jb * blksz + ib] = Alin[(ia * blksz + ib) + (ja * blksz + jb) * N];
+                    (*A[ja * nblks + ia].write())[jb * blksz + ib] = Alin[(ia * blksz + ib) + (ja * blksz + jb) * N];
 
     print_matrix(A, nblks, blksz);
 

--- a/examples/game_of_life.cpp
+++ b/examples/game_of_life.cpp
@@ -123,8 +123,8 @@ int main(int, char*[])
                                 dst[{x + xi, y + yi}]
                                     = next_state((Cell const(*)[size.x + 2]) & (src[{x + xi, y + yi}]));
                     },
-                    buffers[next].write().area({x, y}, {x + chunk_size.x, y + chunk_size.y}),
-                    buffers[current].read().area({x - 1, y - 1}, {x + chunk_size.x + 2, y + chunk_size.y + 2}));
+                    buffers[next].write({x, y}, {x + chunk_size.x, y + chunk_size.y}),
+                    buffers[current].read({x - 1, y - 1}, {x + chunk_size.x + 2, y + chunk_size.y + 2}));
 
         current = next;
     }

--- a/examples/mpi.cpp
+++ b/examples/mpi.cpp
@@ -140,7 +140,7 @@ int main()
 
                   mpi_request_pool->get_status(request);
               },
-              field[current].at({3}).read(),
+              field[current].read({3}),
               mpi_config.read())
             .enable_stack_switching();
 
@@ -158,18 +158,18 @@ int main()
                   int recv_data_count;
                   MPI_Get_count(&status, MPI_CHAR, &recv_data_count);
               },
-              field[current].at({0}).write(),
+              field[current].write({0}),
               mpi_config.read())
             .enable_stack_switching();
 
         /*
          * Compute iteration
          */
-        for(size_t i = 1; i < field[current]->size(); ++i)
+        for(size_t i = 1; i < field[current].getObject()->size(); ++i)
             rg.emplace_task(
                 [i](auto dst, auto src) { dst[{i}] = src[{i - 1}]; },
-                field[next].at({i}).write(),
-                field[current].at({i - 1}).read());
+                field[next].write({i}),
+                field[current].read({i - 1}));
 
         /*
          * Write Output

--- a/redGrapes/SchedulerDescription.hpp
+++ b/redGrapes/SchedulerDescription.hpp
@@ -29,7 +29,7 @@ namespace redGrapes
         using Key = TTag;
         using ValueType = TScheduler;
 
-        SchedulerDescription(std::shared_ptr<TScheduler> scheduler, TTag = DefaultTag{}) : scheduler{scheduler}
+        SchedulerDescription(std::shared_ptr<TScheduler> const& scheduler, TTag = DefaultTag{}) : scheduler{scheduler}
         {
         }
 

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -10,8 +10,6 @@
 #include "redGrapes/SchedulerDescription.hpp"
 #include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/globalSpace.hpp"
-#include "redGrapes/resource/fieldresource.hpp"
-#include "redGrapes/resource/ioresource.hpp"
 #include "redGrapes/scheduler/event.hpp"
 #include "redGrapes/scheduler/pool_scheduler.hpp"
 #include "redGrapes/task/task.hpp"
@@ -139,7 +137,10 @@ namespace redGrapes
 
             SPDLOG_TRACE("emplace task to worker {}", worker_id);
 
-            using Impl = typename std::invoke_result_t<BindArgs<Callable, Args...>, Callable, Args...>;
+            using Impl = typename std::invoke_result_t<
+                BindArgs<Callable, decltype(forward_arg(std::declval<Args>()))...>,
+                Callable,
+                decltype(forward_arg(std::declval<Args>()))...>;
             // this is not set to nullptr. But it goes out of scope. Memory is managed by allocate
             FunTask<Impl, RGTask>* task;
             memory::Allocator alloc(worker_id);
@@ -175,30 +176,6 @@ namespace redGrapes
         auto& getScheduler()
         {
             return getScheduler<DefaultTag>();
-        }
-
-        template<typename Container>
-        auto createFieldResource(Container* c) -> FieldResource<Container>
-        {
-            return FieldResource<Container>(c);
-        }
-
-        template<typename Container, typename... Args>
-        auto createFieldResource(Args&&... args) -> FieldResource<Container>
-        {
-            return FieldResource<Container>(std::forward<Args>(args)...);
-        }
-
-        template<typename T>
-        auto createIOResource(std::shared_ptr<T> const& o) -> IOResource<T>
-        {
-            return IOResource<T>(o);
-        }
-
-        template<typename T, typename... Args>
-        auto createIOResource(Args&&... args) -> IOResource<T>
-        {
-            return IOResource<T>(std::forward<Args>(args)...);
         }
 
         template<typename AccessPolicy>

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -190,7 +190,7 @@ namespace redGrapes
         }
 
         template<typename T>
-        auto createIOResource(std::shared_ptr<T> o) -> IOResource<T>
+        auto createIOResource(std::shared_ptr<T> const& o) -> IOResource<T>
         {
             return IOResource<T>(o);
         }

--- a/redGrapes/redGrapes.hpp
+++ b/redGrapes/redGrapes.hpp
@@ -154,10 +154,10 @@ namespace redGrapes
             new(task) FunTask<Impl, RGTask>(worker_id, scope_depth_impl(), *scheduler_map[TSchedTag{}]);
 
             return TaskBuilder<RGTask, Callable, Args...>(
-              task,
-              current_task_space(),
-              std::forward<Callable>(f),
-              std::forward<Args>(args)...);
+                task,
+                current_task_space(),
+                std::forward<Callable>(f),
+                std::forward<Args>(args)...);
         }
 
         template<typename Callable, typename... Args>

--- a/redGrapes/resource/access/field.hpp
+++ b/redGrapes/resource/access/field.hpp
@@ -11,9 +11,9 @@
 
 #pragma once
 
-#include "redGrapes/resource/access/area.hpp"
 #include "redGrapes/resource/access/combine.hpp"
 #include "redGrapes/resource/access/io.hpp"
+#include "redGrapes/resource/access/range.hpp"
 
 namespace redGrapes
 {
@@ -21,7 +21,7 @@ namespace redGrapes
     {
 
         template<size_t dimension_t>
-        using FieldAccess = CombineAccess<IOAccess, ArrayAccess<AreaAccess, dimension_t, And_t>, And_t>;
+        using FieldAccess = CombineAccess<IOAccess, ArrayAccess<RangeAccess, dimension_t, And_t>, And_t>;
 
     } // namespace access
 

--- a/redGrapes/resource/access/io.hpp
+++ b/redGrapes/resource/access/io.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <fmt/format.h>
 
 namespace redGrapes
@@ -22,7 +23,7 @@ namespace redGrapes
          */
         struct IOAccess
         {
-            enum Mode
+            enum Mode : uint8_t
             {
                 write,
                 read,

--- a/redGrapes/resource/access/io.hpp
+++ b/redGrapes/resource/access/io.hpp
@@ -11,8 +11,9 @@
 
 #pragma once
 
-#include <cstdint>
 #include <fmt/format.h>
+
+#include <cstdint>
 
 namespace redGrapes
 {

--- a/redGrapes/resource/access/range.hpp
+++ b/redGrapes/resource/access/range.hpp
@@ -20,16 +20,16 @@ namespace redGrapes
 {
     namespace access
     {
-
-        struct AreaAccess : std::array<size_t, 2>
+        // Must be in increasing order
+        struct RangeAccess : std::array<size_t, 2>
         {
-            AreaAccess()
+            RangeAccess()
             {
                 (*this)[0] = std::numeric_limits<size_t>::min();
                 (*this)[1] = std::numeric_limits<size_t>::max();
             }
 
-            AreaAccess(std::array<size_t, 2> a) : std::array<size_t, 2>(a)
+            RangeAccess(std::array<size_t, 2> a) : std::array<size_t, 2>(a)
             {
             }
 
@@ -39,17 +39,17 @@ namespace redGrapes
                        && (*this)[1] == std::numeric_limits<size_t>::max();
             }
 
-            static bool is_serial(AreaAccess const& a, AreaAccess const& b)
+            static bool is_serial(RangeAccess const& a, RangeAccess const& b)
             {
-                return (a[1] > b[0]) && (a[0] < b[1]);
+                return !((a[1] <= b[0]) || (a[0] >= b[1]));
             }
 
-            bool is_superset_of(AreaAccess const& a) const
+            bool is_superset_of(RangeAccess const& a) const
             {
                 return (((*this)[0] <= a[0]) && ((*this)[1] >= a[1]));
             }
 
-            bool operator==(AreaAccess const& other) const
+            bool operator==(RangeAccess const& other) const
             {
                 return (*this)[0] == other[0] && (*this)[1] == other[1];
             }
@@ -62,7 +62,7 @@ namespace redGrapes
 } // namespace redGrapes
 
 template<>
-struct fmt::formatter<redGrapes::access::AreaAccess>
+struct fmt::formatter<redGrapes::access::RangeAccess>
 {
     constexpr auto parse(format_parse_context& ctx)
     {
@@ -70,7 +70,7 @@ struct fmt::formatter<redGrapes::access::AreaAccess>
     }
 
     template<typename FormatContext>
-    auto format(redGrapes::access::AreaAccess const& acc, FormatContext& ctx) const
+    auto format(redGrapes::access::RangeAccess const& acc, FormatContext& ctx)
     {
         return fmt::format_to(ctx.out(), "{{ \"area\" : {{ \"begin\" : {}, \"end\" : {} }} }}", acc[0], acc[1]);
     }

--- a/redGrapes/resource/fieldresource.hpp
+++ b/redGrapes/resource/fieldresource.hpp
@@ -11,10 +11,11 @@
 
 #pragma once
 
-#include "redGrapes/TaskFreeCtx.hpp"
 #include "redGrapes/resource/access/field.hpp"
 #include "redGrapes/resource/resource.hpp"
 #include "redGrapes/util/traits.hpp"
+
+#include <type_traits>
 
 namespace redGrapes
 {
@@ -38,7 +39,24 @@ namespace redGrapes
                 return {v.size()};
             }
 
-            static Item& get(std::vector<T>& v, std::array<size_t, dim> index)
+            static Item& get(std::vector<T>& v, std::array<size_t, dim> const& index)
+            {
+                return v[index[0]];
+            }
+        };
+
+        template<typename T>
+        struct Field<std::vector<T> const>
+        {
+            using Item = T;
+            static constexpr size_t dim = 1;
+
+            static std::array<size_t, dim> extent(std::vector<T>& v)
+            {
+                return {v.size()};
+            }
+
+            static Item const& get(std::vector<T> const& v, std::array<size_t, dim> const& index)
             {
                 return v[index[0]];
             }
@@ -50,7 +68,19 @@ namespace redGrapes
             using Item = T;
             static constexpr size_t dim = 1;
 
-            static Item& get(std::array<T, N>& array, std::array<size_t, dim> index)
+            static Item& get(std::array<T, N>& array, std::array<size_t, dim> const& index)
+            {
+                return array[index[0]];
+            }
+        };
+
+        template<typename T, size_t N>
+        struct Field<std::array<T, N> const>
+        {
+            using Item = T;
+            static constexpr size_t dim = 1;
+
+            static Item const& get(std::array<T, N> const& array, std::array<size_t, dim> const& index)
             {
                 return array[index[0]];
             }
@@ -62,13 +92,84 @@ namespace redGrapes
             using Item = T;
             static constexpr size_t dim = 2;
 
-            static Item& get(std::array<std::array<T, Nx>, Ny>& array, std::array<size_t, dim> index)
+            static Item& get(std::array<std::array<T, Nx>, Ny>& array, std::array<size_t, dim> const& index)
             {
                 return array[index[1]][index[0]];
             }
         };
 
+        template<typename T, size_t Nx, size_t Ny>
+        struct Field<std::array<std::array<T, Nx>, Ny> const>
+        {
+            using Item = T;
+            static constexpr size_t dim = 2;
+
+            static Item const& get(
+                std::array<std::array<T, Nx>, Ny> const& array,
+                std::array<size_t, dim> const& index)
+            {
+                return array[index[1]][index[0]];
+            }
+        };
+
+
     }; // namespace trait
+
+    namespace fieldaccess
+    {
+
+        template<typename Container>
+        struct FieldAccessWrapper
+        {
+            static constexpr size_t dim = trait::Field<Container>::dim;
+            using Index = std::array<size_t, dim>;
+
+            FieldAccessWrapper(std::shared_ptr<Container> container) : container(std::move(container)), m_area{}
+            {
+            }
+
+            FieldAccessWrapper(
+                std::shared_ptr<Container> container,
+                access::ArrayAccess<access::RangeAccess, dim> area)
+                : container(std::move(container))
+                , m_area{area}
+            {
+            }
+
+            auto* operator->() const noexcept
+            {
+                return container.get();
+            }
+
+            auto& operator[](Index const& index) const
+            {
+                return get(index);
+            }
+
+            auto& get(Index const& index) const noexcept
+            {
+                if(!contains(index))
+                    throw std::out_of_range("invalid area access");
+
+                return trait::Field<Container>::get(*container, index);
+            }
+
+        private:
+            bool contains(Index index) const noexcept
+            {
+                for(size_t d = 0; d < dim; d++)
+                {
+                    if(index[d] < m_area[d][0] || index[d] >= m_area[d][1])
+                        return false;
+                }
+                return true;
+            }
+
+            std::shared_ptr<Container> container;
+            access::ArrayAccess<access::RangeAccess, dim> m_area;
+        };
+
+    } // namespace fieldaccess
 
     namespace fieldresource
     {
@@ -80,238 +181,121 @@ namespace redGrapes
             using Item = typename trait::Field<Container>::Item;
             using Index = std::array<size_t, dim>;
 
-            bool contains(Index index) const noexcept
-            {
-                for(size_t d = 0; d < dim; d++)
-                {
-                    if(index[d] < m_area[d][0] || index[d] >= m_area[d][1])
-                        return false;
-                }
-                return true;
-            }
-
-        protected:
-            AreaGuard(ResourceId id, std::shared_ptr<Container> const& obj)
-                : SharedResourceObject<Container, access::FieldAccess<dim>>(id, obj)
+            AreaGuard(std::shared_ptr<Container> const& obj)
+                : SharedResourceObject<Container, access::FieldAccess<dim>>(obj)
+                , m_area{}
             {
             }
 
             template<typename... Args>
-            AreaGuard(ResourceId id, Args&&... args)
-                : SharedResourceObject<Container, access::FieldAccess<dim>>(id, std::forward<Args>(args)...)
+            requires(!(traits::is_specialization_of_v<std::decay_t<traits::first_type_t<Args...>>, AreaGuard>
+                       || std::is_same_v<std::decay_t<traits::first_type_t<Args...>>, Container*>) )
+
+            AreaGuard(Args&&... args)
+                : SharedResourceObject<Container, access::FieldAccess<dim>>(std::forward<Args>(args)...)
+                , m_area{}
             {
             }
 
-            AreaGuard(
-                Resource<access::FieldAccess<trait::Field<Container>::dim>> const& res,
-                std::shared_ptr<Container> const& obj)
+            template<typename TContainer>
+            AreaGuard(AreaGuard<TContainer> const& res, std::shared_ptr<Container> const& obj)
                 : SharedResourceObject<Container, access::FieldAccess<dim>>(res, obj)
+                , m_area{}
             {
             }
 
-            template<typename... Args>
-            AreaGuard(Resource<access::FieldAccess<trait::Field<Container>::dim>> const& res, Args&&... args)
+            template<typename TContainer, typename... Args>
+            AreaGuard(AreaGuard<TContainer> const& res, Args&&... args)
                 : SharedResourceObject<Container, access::FieldAccess<dim>>(res, std::forward<Args>(args)...)
+                , m_area{}
             {
             }
 
-            AreaGuard(AreaGuard const& other, Index begin, Index end)
-                : SharedResourceObject<Container, access::FieldAccess<dim>>(other)
-                , m_area(other.make_area(begin, end))
+            access::ArrayAccess<access::RangeAccess, dim> make_area(Index begin, Index end) const
             {
-            }
-
-            Item& get(Index index) const
-            {
-                if(!contains(index))
-                    throw std::out_of_range("invalid area access");
-
-                return trait::Field<Container>::get(*this->obj, index);
-            }
-
-            access::ArrayAccess<access::AreaAccess, dim> make_area(Index begin, Index end) const
-            {
-                std::array<access::AreaAccess, dim> sub_area;
+                std::array<access::RangeAccess, dim> sub_area;
                 for(int d = 0; d < dim; ++d)
-                    sub_area[d] = access::AreaAccess({begin[d], end[d]});
+                    sub_area[d] = access::RangeAccess({begin[d], end[d]});
 
                 if(!m_area.is_superset_of(sub_area))
                     throw std::out_of_range("invalid sub area");
 
-                return access::ArrayAccess<access::AreaAccess, dim>(sub_area);
-            }
-
-            access::ArrayAccess<access::AreaAccess, dim> m_area;
-        };
-
-        template<typename Container>
-        struct ReadGuard : AreaGuard<Container>
-        {
-            static constexpr size_t dim = trait::Field<Container>::dim;
-            using typename AreaGuard<Container>::Index;
-            using typename AreaGuard<Container>::Item;
-
-            ReadGuard read() const noexcept
-            {
-                return *this;
-            }
-
-            ReadGuard area(Index begin, Index end) const
-            {
-                return ReadGuard(*this, begin, end);
-            }
-
-            ReadGuard at(Index pos) const
-            {
-                Index end = pos;
-                for(size_t d = 0; d < dim; ++d)
-                    end[d]++;
-                return ReadGuard(*this, pos, end);
-            }
-
-            Item const& operator[](Index index) const
-            {
-                return this->get(index);
-            }
-
-            Container const* operator->() const noexcept
-            {
-                return this->obj.get();
-            }
-
-            operator ResourceAccess() const noexcept
-            {
-                return this->res.make_access(access::FieldAccess<dim>(access::IOAccess::read, this->m_area));
+                return access::ArrayAccess<access::RangeAccess, dim>(sub_area);
             }
 
         protected:
-            ReadGuard(ReadGuard const& other, Index begin, Index end) : AreaGuard<Container>(other, begin, end)
-            {
-            }
-
-            ReadGuard(ResourceId id, std::shared_ptr<Container> const& obj) : AreaGuard<Container>(id, obj)
-            {
-            }
-
-            template<typename... Args>
-            ReadGuard(ResourceId id, Args&&... args) : AreaGuard<Container>(id, std::forward<Args>(args)...)
-            {
-            }
-
-            ReadGuard(
-                Resource<access::FieldAccess<trait::Field<Container>::dim>> const& res,
-                std::shared_ptr<Container> const& obj)
-                : AreaGuard<Container>(res, obj)
-            {
-            }
-
-            template<typename... Args>
-            ReadGuard(Resource<access::FieldAccess<trait::Field<Container>::dim>> const& res, Args&&... args)
-                : AreaGuard<Container>(res, std::forward<Args>(args)...)
-            {
-            }
+            access::ArrayAccess<access::RangeAccess, dim> m_area;
         };
 
-        template<typename Container>
-        struct WriteGuard : ReadGuard<Container>
-        {
-            static constexpr size_t dim = trait::Field<Container>::dim;
-            using typename ReadGuard<Container>::Index;
-            using typename ReadGuard<Container>::Item;
-
-            WriteGuard write() const noexcept
-            {
-                return *this;
-            }
-
-            WriteGuard area(Index begin, Index end) const
-            {
-                return WriteGuard(*this, begin, end);
-            }
-
-            WriteGuard at(Index pos) const
-            {
-                Index end = pos;
-                for(size_t d = 0; d < dim; ++d)
-                    end[d]++;
-                return WriteGuard(*this, pos, end);
-            }
-
-            Item& operator[](Index index) const
-            {
-                return this->get(index);
-            }
-
-            Container* operator->() const noexcept
-            {
-                return this->obj.get();
-            }
-
-            operator ResourceAccess() const noexcept
-            {
-                return this->res.make_access(access::FieldAccess<dim>(access::IOAccess::write, this->m_area));
-            }
-
-        protected:
-            WriteGuard(WriteGuard const& other, Index begin, Index end) : ReadGuard<Container>(other, begin, end)
-            {
-            }
-
-            WriteGuard(ResourceId id, std::shared_ptr<Container> const& obj) : ReadGuard<Container>(id, obj)
-            {
-            }
-
-            template<typename... Args>
-            WriteGuard(ResourceId id, Args&&... args) : ReadGuard<Container>(id, std::forward<Args>(args)...)
-            {
-            }
-
-            WriteGuard(
-                Resource<access::FieldAccess<trait::Field<Container>::dim>> const& res,
-                std::shared_ptr<Container> const& obj)
-                : ReadGuard<Container>(res, obj)
-            {
-            }
-
-            template<typename... Args>
-            WriteGuard(Resource<access::FieldAccess<trait::Field<Container>::dim>> const& res, Args&&... args)
-                : ReadGuard<Container>(res, std::forward<Args>(args)...)
-            {
-            }
-        };
 
     } // namespace fieldresource
 
     template<typename Container>
-    struct FieldResource : fieldresource::WriteGuard<Container>
+    struct FieldResource : fieldresource::AreaGuard<Container>
     {
         static constexpr size_t dim = trait::Field<Container>::dim;
+        using typename fieldresource::AreaGuard<Container>::Index;
+        using typename fieldresource::AreaGuard<Container>::Item;
 
-        FieldResource(Container* c)
-            : fieldresource::WriteGuard<Container>(TaskFreeCtx::create_resource_uid(), std::make_shared<Container>(c))
+        using fieldresource::AreaGuard<Container>::AreaGuard;
+
+        auto access(access::FieldAccess<dim> mode) const noexcept
         {
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container>>{
+                this->obj,
+                this->res.make_access(mode)};
         }
 
-        template<typename... Args>
-        requires(
-            !(traits::is_specialization_of_v<std::decay_t<traits::first_type_t<Args...>>, FieldResource>
-              || std::is_same_v<std::decay_t<traits::first_type_t<Args...>>, Container*>) )
-
-        FieldResource(Args&&... args)
-            : fieldresource::WriteGuard<Container>(TaskFreeCtx::create_resource_uid(), std::forward<Args>(args)...)
+        auto read() const noexcept
         {
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container const>>{
+                this->obj,
+                this->res.make_access(access::FieldAccess<dim>(
+                    access::IOAccess::read,
+                    access::ArrayAccess<access::RangeAccess, dim>{}))};
         }
 
-        template<typename U>
-        FieldResource(FieldResource<U> const& res, Container* c)
-            : fieldresource::WriteGuard<Container>(res, std::make_shared<Container>(c))
+        auto read(Index begin, Index end) const noexcept
         {
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container const>>{
+                this->obj,
+                this->res.make_access(access::FieldAccess<dim>(access::IOAccess::read, this->make_area(begin, end)))};
         }
 
-        template<typename U, typename... Args>
-        FieldResource(FieldResource<U> const& res, Args&&... args)
-            : fieldresource::WriteGuard<Container>(res, std::forward<Args>(args)...)
+        auto read(Index pos) const noexcept
         {
+            Index end = pos;
+            for(size_t d = 0; d < dim; ++d)
+                end[d]++;
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container const>>{
+                {this->obj, this->make_area(pos, end)},
+                this->res.make_access(access::FieldAccess<dim>(access::IOAccess::read, this->make_area(pos, end)))};
+        }
+
+        auto write() const noexcept
+        {
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container>>{
+                this->obj,
+                this->res.make_access(access::FieldAccess<dim>(
+                    access::IOAccess::write,
+                    access::ArrayAccess<access::RangeAccess, dim>{}))};
+        }
+
+        auto write(Index begin, Index end) const noexcept
+        {
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container>>{
+                this->obj,
+                this->res.make_access(access::FieldAccess<dim>(access::IOAccess::write, this->make_area(begin, end)))};
+        }
+
+        auto write(Index pos) const noexcept
+        {
+            Index end = pos;
+            for(size_t d = 0; d < dim; ++d)
+                end[d]++;
+            return ResourceAccessPair<fieldaccess::FieldAccessWrapper<Container>>{
+                this->obj,
+                this->res.make_access(access::FieldAccess<dim>(access::IOAccess::write, this->make_area(pos, end)))};
         }
     };
 

--- a/redGrapes/resource/fieldresource.hpp
+++ b/redGrapes/resource/fieldresource.hpp
@@ -288,7 +288,7 @@ namespace redGrapes
         static constexpr size_t dim = trait::Field<Container>::dim;
 
         FieldResource(Container* c)
-            : fieldresource::WriteGuard<Container>(TaskFreeCtx::create_resource_uid(), std::shared_ptr<Container>(c))
+            : fieldresource::WriteGuard<Container>(TaskFreeCtx::create_resource_uid(), std::make_shared<Container>(c))
         {
         }
 
@@ -304,7 +304,7 @@ namespace redGrapes
 
         template<typename U>
         FieldResource(FieldResource<U> const& res, Container* c)
-            : fieldresource::WriteGuard<Container>(res, std::shared_ptr<Container>(c))
+            : fieldresource::WriteGuard<Container>(res, std::make_shared<Container>(c))
         {
         }
 

--- a/redGrapes/resource/fieldresource.hpp
+++ b/redGrapes/resource/fieldresource.hpp
@@ -181,7 +181,7 @@ namespace redGrapes
 
             operator ResourceAccess() const noexcept
             {
-                return this->make_access(access::FieldAccess<dim>(access::IOAccess::read, this->m_area));
+                return this->res.make_access(access::FieldAccess<dim>(access::IOAccess::read, this->m_area));
             }
 
         protected:
@@ -249,7 +249,7 @@ namespace redGrapes
 
             operator ResourceAccess() const noexcept
             {
-                return this->make_access(access::FieldAccess<dim>(access::IOAccess::write, this->m_area));
+                return this->res.make_access(access::FieldAccess<dim>(access::IOAccess::write, this->m_area));
             }
 
         protected:

--- a/redGrapes/resource/resource.hpp
+++ b/redGrapes/resource/resource.hpp
@@ -418,6 +418,17 @@ namespace redGrapes
         {
         }
 
+        auto read() const noexcept
+        {
+            return ResourceAccessPair<T const>{obj, res.make_access(AccessPolicy::read)};
+        }
+
+        auto write() const noexcept
+        {
+            return ResourceAccessPair<T>{obj, res.make_access(AccessPolicy::write)};
+        }
+
+
     protected:
         Resource<AccessPolicy> res;
         std::shared_ptr<T> obj;

--- a/redGrapes/resource/resource.hpp
+++ b/redGrapes/resource/resource.hpp
@@ -88,7 +88,7 @@ namespace redGrapes
     {
         AccessBase(boost::typeindex::type_index access_type, std::shared_ptr<ResourceBase> resource)
             : access_type(access_type)
-            , resource(resource)
+            , resource(std::move(resource))
         {
         }
 
@@ -116,7 +116,7 @@ namespace redGrapes
     template<typename AccessPolicy>
     struct Access : public AccessBase
     {
-        Access(std::shared_ptr<ResourceBase> resource, AccessPolicy policy)
+        Access(std::shared_ptr<ResourceBase> const& resource, AccessPolicy policy)
             : AccessBase(boost::typeindex::type_id<AccessPolicy>(), resource)
             , policy(policy)
         {
@@ -394,7 +394,7 @@ namespace redGrapes
     template<typename T, typename AccessPolicy>
     struct SharedResourceObject
     {
-        SharedResourceObject(ResourceId id, std::shared_ptr<T> const& obj) : res{id}, obj(obj)
+        SharedResourceObject(ResourceId id, std::shared_ptr<T> obj) : res{id}, obj(std::move(obj))
         {
         }
 
@@ -405,7 +405,7 @@ namespace redGrapes
         {
         }
 
-        SharedResourceObject(Resource<AccessPolicy> const& res, std::shared_ptr<T> const& obj) : res{res}, obj{obj}
+        SharedResourceObject(Resource<AccessPolicy> const& res, std::shared_ptr<T> obj) : res{res}, obj{std::move(obj)}
         {
         }
 

--- a/redGrapes/resource/resource.hpp
+++ b/redGrapes/resource/resource.hpp
@@ -240,9 +240,10 @@ namespace redGrapes
             return this->obj->mode_format();
         }
 
-        std::shared_ptr<ResourceBase> get_resource()
+        // Doesn't share ownership
+        ResourceBase* get_resource_ptr() const
         {
-            return obj->resource;
+            return (obj->resource).get();
         }
 
         /**

--- a/redGrapes/resource/resource_user.hpp
+++ b/redGrapes/resource/resource_user.hpp
@@ -68,7 +68,7 @@ namespace redGrapes
         void add_resource_access(ResourceAccess ra)
         {
             this->access_list.push(ra);
-            std::shared_ptr<ResourceBase> r = ra.get_resource();
+            const std::shared_ptr<ResourceBase>& r = ra.get_resource();
             unique_resources.push(ResourceUsageEntry{r, r->users.rend()});
         }
 
@@ -81,7 +81,7 @@ namespace redGrapes
         {
             for(auto ra = access_list.rbegin(); ra != access_list.rend(); ++ra)
             {
-                std::shared_ptr<ResourceBase> r = ra->get_resource();
+                const std::shared_ptr<ResourceBase>& r = ra->get_resource();
                 unique_resources.erase(ResourceUsageEntry{r, r->users.rend()});
                 unique_resources.push(ResourceUsageEntry{r, r->users.rend()});
             }
@@ -121,7 +121,7 @@ namespace redGrapes
                 for(auto rb = b.access_list.crbegin(); rb != b.access_list.crend(); ++rb)
                 {
                     TRACE_EVENT("ResourceUser", "RA::is_serial");
-                    if(ResourceAccess::is_serial(*ra, *rb))
+                    if(is_serial(*ra, *rb))
                         return true;
                 }
             return false;

--- a/redGrapes/scheduler/pool_scheduler.hpp
+++ b/redGrapes/scheduler/pool_scheduler.hpp
@@ -55,7 +55,7 @@ namespace redGrapes
 
             WorkerId getNextWorkerID();
 
-            void init(WorkerId base_id);
+            void init(WorkerId base_id) override;
 
             void startExecution();
 

--- a/redGrapes/scheduler/thread_scheduler.hpp
+++ b/redGrapes/scheduler/thread_scheduler.hpp
@@ -86,7 +86,7 @@ namespace redGrapes
                 return m_base_id;
             }
 
-            virtual void init(WorkerId base_id)
+            void init(WorkerId base_id) override
             {
                 m_base_id = base_id;
                 // TODO check if it was already initalized

--- a/redGrapes/scheduler/thread_scheduler.hpp
+++ b/redGrapes/scheduler/thread_scheduler.hpp
@@ -33,7 +33,7 @@ namespace redGrapes
             }
 
             ThreadScheduler(std::shared_ptr<dispatch::thread::WorkerThread<Worker>> workerThread)
-                : m_worker_thread(workerThread)
+                : m_worker_thread(std::move(workerThread))
             {
             }
 

--- a/redGrapes/task/property/resource.hpp
+++ b/redGrapes/task/property/resource.hpp
@@ -49,7 +49,7 @@ namespace redGrapes
                 return builder;
             }
 
-            inline PropertiesBuilder& add_resource(ResourceAccess access)
+            inline PropertiesBuilder& add_resource(ResourceAccess const& access)
             {
                 (*builder.task) += access;
                 return builder;

--- a/redGrapes/util/atomic_list.hpp
+++ b/redGrapes/util/atomic_list.hpp
@@ -289,7 +289,7 @@ namespace redGrapes
              * and returns the previous head to which the new_head
              * is now linked.
              */
-            auto append_item(std::shared_ptr<ItemControlBlock> new_head)
+            auto append_item(std::shared_ptr<ItemControlBlock> const& new_head)
             {
                 TRACE_EVENT("Allocator", "AtomicList::append_item()");
                 std::shared_ptr<ItemControlBlock> old_head;
@@ -306,7 +306,7 @@ namespace redGrapes
             }
 
             // append the first head item if not already exists
-            bool try_append_first_item(std::shared_ptr<ItemControlBlock> new_head)
+            bool try_append_first_item(std::shared_ptr<ItemControlBlock> const& new_head)
             {
                 TRACE_EVENT("Allocator", "AtomicList::append_first_item()");
 

--- a/redGrapes/util/traits.hpp
+++ b/redGrapes/util/traits.hpp
@@ -1,5 +1,14 @@
+/* Copyright 2024 Tapish Narwal
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 #pragma once
+
 #include <type_traits>
+#include <utility>
 
 namespace redGrapes::traits
 {
@@ -28,5 +37,33 @@ namespace redGrapes::traits
     // Convenience alias template
     template<typename... Ts>
     using first_type_t = typename first_type<Ts...>::type;
+
+    template<typename T>
+    struct is_pair : std::false_type
+    {
+    };
+
+    template<typename T, typename U>
+    struct is_pair<std::pair<T, U>> : std::true_type
+    {
+    };
+
+    template<typename T>
+    inline constexpr bool is_pair_v = is_pair<T>::value;
+
+    template<typename T, typename = void>
+    struct is_derived_from_pair : std::false_type
+    {
+    };
+
+    // Specialization for std::pair
+    template<typename T>
+    struct is_derived_from_pair<T, std::void_t<typename T::first_type, typename T::second_type>> : std::true_type
+    {
+    };
+
+    // Helper variable template for is_derived_from_pair
+    template<typename T>
+    constexpr bool is_derived_from_pair_v = is_derived_from_pair<T>::value;
 
 } // namespace redGrapes::traits

--- a/test/access.cpp
+++ b/test/access.cpp
@@ -1,8 +1,8 @@
 
-#include <redGrapes/resource/access/area.hpp>
 #include <redGrapes/resource/access/combine.hpp>
 #include <redGrapes/resource/access/field.hpp>
 #include <redGrapes/resource/access/io.hpp>
+#include <redGrapes/resource/access/range.hpp>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -52,86 +52,86 @@ TEST_CASE("IOAccess")
     REQUIRE(IOAccess{IOAccess::amul}.is_superset_of(IOAccess{IOAccess::amul}) == true);
 }
 
-TEST_CASE("AreaAccess")
+TEST_CASE("RangeAccess")
 {
     // --[-----]--(-----)--
-    REQUIRE(AreaAccess::is_serial(AreaAccess({10, 20}), AreaAccess({30, 40})) == false);
-    REQUIRE(AreaAccess({10, 20}).is_superset_of(AreaAccess({30, 40})) == false);
+    REQUIRE(RangeAccess::is_serial(RangeAccess({10, 20}), RangeAccess({30, 40})) == false);
+    REQUIRE(RangeAccess({10, 20}).is_superset_of(RangeAccess({30, 40})) == false);
     // --(-----)--[-----]--
-    REQUIRE(AreaAccess::is_serial(AreaAccess({30, 40}), AreaAccess({10, 20})) == false);
-    REQUIRE(AreaAccess({30, 40}).is_superset_of(AreaAccess({10, 20})) == false);
+    REQUIRE(RangeAccess::is_serial(RangeAccess({30, 40}), RangeAccess({10, 20})) == false);
+    REQUIRE(RangeAccess({30, 40}).is_superset_of(RangeAccess({10, 20})) == false);
 
     // --[--(--]--)--
-    REQUIRE(AreaAccess::is_serial(AreaAccess({10, 20}), AreaAccess({15, 25})) == true);
-    REQUIRE(AreaAccess({10, 20}).is_superset_of(AreaAccess({15, 25})) == false);
+    REQUIRE(RangeAccess::is_serial(RangeAccess({10, 20}), RangeAccess({15, 25})) == true);
+    REQUIRE(RangeAccess({10, 20}).is_superset_of(RangeAccess({15, 25})) == false);
     // --(--[--)--]--
-    REQUIRE(AreaAccess::is_serial(AreaAccess({15, 25}), AreaAccess({10, 20})) == true);
-    REQUIRE(AreaAccess({15, 15}).is_superset_of(AreaAccess({10, 20})) == false);
+    REQUIRE(RangeAccess::is_serial(RangeAccess({15, 25}), RangeAccess({10, 20})) == true);
+    REQUIRE(RangeAccess({15, 15}).is_superset_of(RangeAccess({10, 20})) == false);
 
     // --[--(--)--]--
-    REQUIRE(AreaAccess::is_serial(AreaAccess({10, 30}), AreaAccess({15, 25})) == true);
-    REQUIRE(AreaAccess({10, 30}).is_superset_of(AreaAccess({15, 25})) == true);
+    REQUIRE(RangeAccess::is_serial(RangeAccess({10, 30}), RangeAccess({15, 25})) == true);
+    REQUIRE(RangeAccess({10, 30}).is_superset_of(RangeAccess({15, 25})) == true);
     // --(--[--]--)--
-    REQUIRE(AreaAccess::is_serial(AreaAccess({15, 25}), AreaAccess({10, 30})) == true);
-    REQUIRE(AreaAccess({15, 25}).is_superset_of(AreaAccess({10, 30})) == false);
+    REQUIRE(RangeAccess::is_serial(RangeAccess({15, 25}), RangeAccess({10, 30})) == true);
+    REQUIRE(RangeAccess({15, 25}).is_superset_of(RangeAccess({10, 30})) == false);
 }
 
 TEST_CASE("CombineAccess")
 {
-    using A = CombineAccess<IOAccess, AreaAccess, And_t>;
+    using A = CombineAccess<IOAccess, RangeAccess, And_t>;
 
     REQUIRE(
         A::is_serial(
-            A(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            A(IOAccess{IOAccess::read}, AreaAccess({15, 25})))
+            A(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            A(IOAccess{IOAccess::read}, RangeAccess({15, 25})))
         == false);
 
     REQUIRE(
         A::is_serial(
-            A(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            A(IOAccess{IOAccess::write}, AreaAccess({15, 25})))
+            A(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            A(IOAccess{IOAccess::write}, RangeAccess({15, 25})))
         == true);
 
     REQUIRE(
         A::is_serial(
-            A(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            A(IOAccess{IOAccess::write}, AreaAccess({30, 40})))
+            A(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            A(IOAccess{IOAccess::write}, RangeAccess({30, 40})))
         == false);
 
     REQUIRE(
-        A(IOAccess{IOAccess::read}, AreaAccess({10, 20}))
-            .is_superset_of(A(IOAccess{IOAccess::read}, AreaAccess({15, 25})))
+        A(IOAccess{IOAccess::read}, RangeAccess({10, 20}))
+            .is_superset_of(A(IOAccess{IOAccess::read}, RangeAccess({15, 25})))
         == false);
 
     REQUIRE(
-        A(IOAccess{IOAccess::write}, AreaAccess({10, 30}))
-            .is_superset_of(A(IOAccess{IOAccess::read}, AreaAccess({15, 25})))
+        A(IOAccess{IOAccess::write}, RangeAccess({10, 30}))
+            .is_superset_of(A(IOAccess{IOAccess::read}, RangeAccess({15, 25})))
         == true);
 
-    using B = CombineAccess<IOAccess, AreaAccess, Or_t>;
+    using B = CombineAccess<IOAccess, RangeAccess, Or_t>;
 
     REQUIRE(
         B::is_serial(
-            B(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            B(IOAccess{IOAccess::read}, AreaAccess({30, 40})))
+            B(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            B(IOAccess{IOAccess::read}, RangeAccess({30, 40})))
         == false);
 
     REQUIRE(
         B::is_serial(
-            B(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            B(IOAccess{IOAccess::read}, AreaAccess({15, 25})))
-        == true);
-
-    REQUIRE(
-        B::is_serial(
-            B(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            B(IOAccess{IOAccess::write}, AreaAccess({15, 25})))
+            B(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            B(IOAccess{IOAccess::read}, RangeAccess({15, 25})))
         == true);
 
     REQUIRE(
         B::is_serial(
-            B(IOAccess{IOAccess::read}, AreaAccess({10, 20})),
-            B(IOAccess{IOAccess::write}, AreaAccess({30, 40})))
+            B(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            B(IOAccess{IOAccess::write}, RangeAccess({15, 25})))
+        == true);
+
+    REQUIRE(
+        B::is_serial(
+            B(IOAccess{IOAccess::read}, RangeAccess({10, 20})),
+            B(IOAccess{IOAccess::write}, RangeAccess({30, 40})))
         == true);
 }
 
@@ -191,24 +191,24 @@ TEST_CASE("ArrayAccess")
 
 TEST_CASE("FieldAccess")
 {
-    using Arr = ArrayAccess<AreaAccess, 3, And_t>;
+    using Arr = ArrayAccess<RangeAccess, 3, And_t>;
     REQUIRE(
         FieldAccess<3>::is_serial(
             FieldAccess<3>(
                 IOAccess{IOAccess::read},
-                Arr({AreaAccess({0, 10}), AreaAccess({0, 10}), AreaAccess({0, 10})})),
+                Arr({RangeAccess({0, 10}), RangeAccess({0, 10}), RangeAccess({0, 10})})),
             FieldAccess<3>(
                 IOAccess{IOAccess::read},
-                Arr({AreaAccess({0, 10}), AreaAccess({0, 10}), AreaAccess({0, 10})})))
+                Arr({RangeAccess({0, 10}), RangeAccess({0, 10}), RangeAccess({0, 10})})))
         == false);
 
     REQUIRE(
         FieldAccess<3>::is_serial(
             FieldAccess<3>(
                 IOAccess{IOAccess::write},
-                Arr({AreaAccess({0, 10}), AreaAccess({0, 10}), AreaAccess({0, 10})})),
+                Arr({RangeAccess({0, 10}), RangeAccess({0, 10}), RangeAccess({0, 10})})),
             FieldAccess<3>(
                 IOAccess{IOAccess::read},
-                Arr({AreaAccess({0, 10}), AreaAccess({0, 10}), AreaAccess({0, 10})})))
+                Arr({RangeAccess({0, 10}), RangeAccess({0, 10}), RangeAccess({0, 10})})))
         == true);
 }

--- a/test/random_graph.cpp
+++ b/test/random_graph.cpp
@@ -186,6 +186,6 @@ TEST_CASE("RandomGraph")
 
         rg.barrier();
         for(unsigned i = 0; i < n_resources; ++i)
-            REQUIRE(*resources[i].read() == expected_hash[i]);
+            REQUIRE(*resources[i].getObject() == expected_hash[i]);
     }
 }

--- a/test/random_graph.cpp
+++ b/test/random_graph.cpp
@@ -186,6 +186,6 @@ TEST_CASE("RandomGraph")
 
         rg.barrier();
         for(unsigned i = 0; i < n_resources; ++i)
-            REQUIRE(*resources[i] == expected_hash[i]);
+            REQUIRE(*resources[i].read() == expected_hash[i]);
     }
 }

--- a/test/resource.cpp
+++ b/test/resource.cpp
@@ -49,16 +49,16 @@ TEST_CASE("Resource ID")
     auto b = rg.createResource<Access>();
 
     // same resource
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.make_access(Access{}), a.make_access(Access{})) == true);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.make_access(Access{}), b.make_access(Access{})) == true);
+    REQUIRE(redGrapes::is_serial(a.make_access(Access{}), a.make_access(Access{})) == true);
+    REQUIRE(redGrapes::is_serial(b.make_access(Access{}), b.make_access(Access{})) == true);
 
     // same resource, but copied
     redGrapes::Resource<Access> a2(a);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.make_access(Access{}), a2.make_access(Access{})) == true);
+    REQUIRE(redGrapes::is_serial(a.make_access(Access{}), a2.make_access(Access{})) == true);
 
     // different resource
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.make_access(Access{}), b.make_access(Access{})) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.make_access(Access{}), a.make_access(Access{})) == false);
+    REQUIRE(redGrapes::is_serial(a.make_access(Access{}), b.make_access(Access{})) == false);
+    REQUIRE(redGrapes::is_serial(b.make_access(Access{}), a.make_access(Access{})) == false);
 }
 
 TEST_CASE("IOResource")
@@ -67,23 +67,23 @@ TEST_CASE("IOResource")
 
     redGrapes::IOResource<int> a, b;
 
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.read(), a.read()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.read(), a.write()) == true);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.write(), a.read()) == true);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.write(), a.write()) == true);
+    REQUIRE(redGrapes::is_serial(a.read(), a.read()) == false);
+    REQUIRE(redGrapes::is_serial(a.read(), a.write()) == true);
+    REQUIRE(redGrapes::is_serial(a.write(), a.read()) == true);
+    REQUIRE(redGrapes::is_serial(a.write(), a.write()) == true);
 
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.read(), b.read()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.read(), b.write()) == true);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.write(), b.read()) == true);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.write(), b.write()) == true);
+    REQUIRE(redGrapes::is_serial(b.read(), b.read()) == false);
+    REQUIRE(redGrapes::is_serial(b.read(), b.write()) == true);
+    REQUIRE(redGrapes::is_serial(b.write(), b.read()) == true);
+    REQUIRE(redGrapes::is_serial(b.write(), b.write()) == true);
 
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.read(), b.read()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.read(), b.write()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.write(), b.read()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(a.write(), b.write()) == false);
+    REQUIRE(redGrapes::is_serial(a.read(), b.read()) == false);
+    REQUIRE(redGrapes::is_serial(a.read(), b.write()) == false);
+    REQUIRE(redGrapes::is_serial(a.write(), b.read()) == false);
+    REQUIRE(redGrapes::is_serial(a.write(), b.write()) == false);
 
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.read(), a.read()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.read(), a.write()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.write(), a.read()) == false);
-    REQUIRE(redGrapes::ResourceAccess::is_serial(b.write(), a.write()) == false);
+    REQUIRE(redGrapes::is_serial(b.read(), a.read()) == false);
+    REQUIRE(redGrapes::is_serial(b.read(), a.write()) == false);
+    REQUIRE(redGrapes::is_serial(b.write(), a.read()) == false);
+    REQUIRE(redGrapes::is_serial(b.write(), a.write()) == false);
 }


### PR DESCRIPTION
Shared resource objects now hold resources in a protected manner instead of inheriting
Use pair of resource access and actual object to seperate how the access is defined and what is passed to the task
