### PR TITLE
Make shared pointer std atomic

### DIFF
--- a/redGrapes/TaskFreeCtx.hpp
+++ b/redGrapes/TaskFreeCtx.hpp
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -36,10 +37,10 @@ namespace redGrapes
         inline memory::ChunkedBumpAlloc<memory::HwlocAlloc>& get_alloc(WorkerId worker_id)
         {
             assert(worker_id < allocs.size());
-            return allocs[worker_id];
+            return *allocs[worker_id];
         }
 
-        std::vector<memory::ChunkedBumpAlloc<memory::HwlocAlloc>> allocs;
+        std::vector<std::unique_ptr<memory::ChunkedBumpAlloc<memory::HwlocAlloc>>> allocs;
     };
 
     struct TaskFreeCtx

--- a/redGrapes/dispatch/thread/worker_pool.tpp
+++ b/redGrapes/dispatch/thread/worker_pool.tpp
@@ -15,6 +15,8 @@
 #include "redGrapes/memory/hwloc_alloc.hpp"
 #include "redGrapes/util/trace.hpp"
 
+#include <memory>
+
 namespace redGrapes
 {
     namespace dispatch
@@ -45,9 +47,10 @@ namespace redGrapes
                     WorkerId pu_id = worker_id % TaskFreeCtx::n_pus;
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
-                    TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(
-                        memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
-                        REDGRAPES_ALLOC_CHUNKSIZE);
+                    TaskFreeCtx::worker_alloc_pool.allocs.push_back(
+                        std::make_unique<memory::ChunkedBumpAlloc<memory::HwlocAlloc>>(
+                            memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
+                            REDGRAPES_ALLOC_CHUNKSIZE));
 
                     auto worker = memory::alloc_shared_bind<WorkerThread<Worker>>(worker_id, obj, worker_id, *this);
                     workers.emplace_back(worker);

--- a/redGrapes/memory/chunked_bump_alloc.hpp
+++ b/redGrapes/memory/chunked_bump_alloc.hpp
@@ -47,12 +47,6 @@ namespace redGrapes
             {
             }
 
-            ChunkedBumpAlloc(ChunkedBumpAlloc&& other)
-                : chunk_size(other.chunk_size)
-                , bump_allocators(other.bump_allocators)
-            {
-            }
-
             static inline size_t roundup_to_poweroftwo(size_t s)
             {
                 s--;

--- a/redGrapes/scheduler/thread_scheduler.hpp
+++ b/redGrapes/scheduler/thread_scheduler.hpp
@@ -96,8 +96,9 @@ namespace redGrapes
                     // allocate worker with id `i` on arena `i`,
                     hwloc_obj_t obj = hwloc_get_obj_by_type(TaskFreeCtx::hwloc_ctx.topology, HWLOC_OBJ_PU, pu_id);
                     TaskFreeCtx::worker_alloc_pool.allocs.emplace_back(
-                        memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
-                        REDGRAPES_ALLOC_CHUNKSIZE);
+                        std::make_unique<memory::ChunkedBumpAlloc<memory::HwlocAlloc>>(
+                            memory::HwlocAlloc(TaskFreeCtx::hwloc_ctx, obj),
+                            REDGRAPES_ALLOC_CHUNKSIZE));
 
                     m_worker_thread
                         = memory::alloc_shared_bind<dispatch::thread::WorkerThread<Worker>>(m_base_id, obj, m_base_id);


### PR DESCRIPTION
Removes use of deprecated atomic operations and now uses std::atomic<std::shared_ptr<T>>